### PR TITLE
bau: Upgrade mockserver version

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <pact.version>3.5.16</pact.version>
-        <mockserver.version>3.10.4</mockserver.version>
+        <mockserver.version>5.3.0</mockserver.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Version 3.10.4 is very old, and when uk.gov.pay:testing was being included in
another project it was causing tests in that project to fail with

```
java.lang.IllegalStateException: org.xml.sax.SAXNotRecognizedException:
http://javax.xml.XMLConstants/feature/secure-processing
```

Upgrading mockserver versions solves the problem.

@oswald.quek