### PR TITLE
PP-3845: Add ability to not publish pacts

### DIFF
--- a/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/MultiPacts.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/MultiPacts.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.commons.testing.pact.consumers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface MultiPacts {
+    Pacts[] value();
+}

--- a/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/Pacts.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/Pacts.java
@@ -1,6 +1,10 @@
 package uk.gov.pay.commons.testing.pact.consumers;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/Pacts.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/Pacts.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.commons.testing.pact.consumers;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
+@Repeatable(MultiPacts.class)
 public @interface Pacts {
     String[] pacts();
+
+    boolean publish() default true;
 }

--- a/testing/src/test/java/uk/gov/pay/commons/testing/pact/consumers/PactProviderRuleTest.java
+++ b/testing/src/test/java/uk/gov/pay/commons/testing/pact/consumers/PactProviderRuleTest.java
@@ -6,9 +6,7 @@ import org.apache.http.client.fluent.Request;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,9 +19,6 @@ public class PactProviderRuleTest {
     @Rule
     public PactProviderRule weatherService = new PactProviderRule("weather-service", this);
 
-    @Rule
-    public PactProviderRule orderService = new PactProviderRule("order-service", this);
-    
     @Test
     @PactVerification({"stock-quote-service"})
     @Pacts(pacts = {"consumer-stock-quote-service-axp"})
@@ -67,17 +62,6 @@ public class PactProviderRuleTest {
         assertThat(map.get("name")).isEqualTo("London");
         assertThat(map.get("temperature")).isEqualTo("25");
         assertThat(map.get("unit")).isEqualTo("degrees");
-    }
-
-    @Test
-    @PactVerification({"weather-service", "order-service"})
-    @Pacts(pacts = {"consumer-weather-service"})
-    @Pacts(pacts = {"consumer-order-service"}, publish = false)
-    public void specifyIfPactShouldBeWritten() throws IOException {
-        Request.Get(weatherService.getUrl() + "/weather/London").execute();
-        Request.Get(orderService.getUrl() + "/orders").execute();
-        assertThat(new File(Paths.get("", "target", "pacts", "consumer-weather-service.json").toAbsolutePath().toString()).exists()).isTrue();
-        assertThat(new File(Paths.get("", "target", "pacts", "consumer-order-service.json").toAbsolutePath().toString()).exists()).isFalse();
     }
 
     private HashMap jsonToMap(String respBody) throws IOException {

--- a/testing/src/test/java/uk/gov/pay/commons/testing/pact/consumers/PactPublishingTest.java
+++ b/testing/src/test/java/uk/gov/pay/commons/testing/pact/consumers/PactPublishingTest.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.commons.testing.pact.consumers;
+
+import au.com.dius.pact.consumer.PactVerification;
+import org.apache.http.client.fluent.Request;
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class PactPublishingTest {
+
+    @Rule
+    public PactProviderRule weatherService = new PactProviderRule("weather-service", this);
+
+    @Rule
+    public PactProviderRule orderService = new PactProviderRule("order-service", this);
+
+    @Test
+    @PactVerification({"weather-service", "order-service"})
+    @Pacts(pacts = {"consumer-weather-service"})
+    @Pacts(pacts = {"consumer-order-service"}, publish = false)
+    public void specifyIfPactShouldBeWritten() throws IOException {
+        Request.Get(weatherService.getUrl() + "/weather/London").execute();
+        Request.Get(orderService.getUrl() + "/orders").execute();
+    }
+
+    @AfterClass
+    public static void after() {
+        assertThat(new File(Paths.get("", "target", "pacts", "consumer-weather-service.json").toAbsolutePath().toString()).exists()).isTrue();
+        assertThat(new File(Paths.get("", "target", "pacts", "consumer-order-service.json").toAbsolutePath().toString()).exists()).isFalse();
+    }
+}

--- a/testing/src/test/resources/pacts/consumer-order-service.json
+++ b/testing/src/test/resources/pacts/consumer-order-service.json
@@ -1,0 +1,32 @@
+{
+  "consumer": {
+    "name": "consumer"
+  },
+  "provider": {
+    "name": "order-service"
+  },
+  "interactions": [
+    {
+      "description": "Get orders",
+      "request": {
+        "method": "GET",
+        "path": "/orders"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": []
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "3.0.0"
+    },
+    "pact-jvm": {
+      "version": "3.5.16"
+    }
+  }
+}


### PR DESCRIPTION
PP-3845 is about checking pact compatibility, e.g. can I deploy service A to
staging given there is service B in staging as well. The issue is sometimes
consumer pact tests are written in development and by default are published to
the pact broker - at this stage no provider tests have been written. This
causes pact compatibility check to fail as the pact broker now has knowledge of
the new pact.

This commit gives the option to not publish a pact by deleting it from the
target/pacts directory, which the pact:publish maven plugin looks into to
publish pacts to the broker.

It would be nice to specify what pacts not to publish in the pact:publish
plugin, an issue has been raised here
https://github.com/DiUS/pact-jvm/issues/711.

@oswaldquek