### PR TITLE
PP-2495: Initialize AWS Xray within a static method

### DIFF
--- a/utils/src/main/java/uk/gov/pay/commons/utils/xray/Xray.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/xray/Xray.java
@@ -5,38 +5,21 @@ import com.amazonaws.xray.AWSXRayRecorderBuilder;
 import com.amazonaws.xray.javax.servlet.AWSXRayServletFilter;
 import com.amazonaws.xray.plugins.ECSPlugin;
 import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
-import io.dropwizard.Bundle;
-import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 import java.net.URL;
-import static java.util.EnumSet.of;
 
+import static java.util.EnumSet.of;
 import static javax.servlet.DispatcherType.REQUEST;
 
-public class AwsXrayBundle implements Bundle {
-    
-    private final String[] urlPatternsForXrayFiltering;
-    private final String xrayServletFilterName;
+public class Xray {
 
-    public AwsXrayBundle(String xrayServletFilterName, String... urlPatternsForXrayFiltering) {
-        this.urlPatternsForXrayFiltering = urlPatternsForXrayFiltering;
-        this.xrayServletFilterName = xrayServletFilterName;
-    }
-
-    /**
-     * @see <a href="http://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html">Configuring the X-Ray SDK for Java</a>
-     */
-    @Override
-    public void initialize(Bootstrap<?> bootstrap) {
+    public static void init(Environment environment, String xrayServletFilterName, String... urlPatternsForXrayFiltering) {
         AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder.standard().withPlugin(new ECSPlugin());
-        URL ruleFile = this.getClass().getResource("/sampling-rules.json");
+        URL ruleFile = Xray.class.getResource("/sampling-rules.json");
         builder.withSamplingStrategy(new LocalizedSamplingStrategy(ruleFile));
         AWSXRay.setGlobalRecorder(builder.build());
-    }
 
-    @Override
-    public void run(Environment environment) {
         environment.servlets().addFilter("AWSXRayServletFilter", new AWSXRayServletFilter(xrayServletFilterName))
                 .addMappingForUrlPatterns(of(REQUEST), true, urlPatternsForXrayFiltering);
     }


### PR DESCRIPTION
It turns out using Bundles does not work. I am not completely sure why but
looking at https://www.dropwizard.io/1.0.5/docs/manual/internals.html it is
possible this is either due to:

1. the Cli not being instantiated before the `bundle.initialize(bootstrap)` is
run
2. the environment is only created during the `cli.run` phase so the xray stuff
needs to be instantiated after the environment is created, not before when
`bundle.initialize(bootstrap)` is run during the `initialize(bootstrap)` phase.

With this commit, dropwizard apps simply need to call Xray.init in the
Application's run method.

@oswaldquek