### PR TITLE
PP-4095 Add new model Maven module with SupportedLanguage enum

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -13,4 +13,13 @@
     <name>Common domain model objects</name>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>pay-java-commons</artifactId>
+        <groupId>uk.gov.pay</groupId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>model</artifactId>
+    <name>Common domain model objects</name>
+    <packaging>jar</packaging>
+
+</project>

--- a/model/src/main/java/uk/gov/pay/commons/model/SupportedLanguage.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/SupportedLanguage.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.commons.model;
+
+public enum SupportedLanguage {
+
+    ENGLISH("en"),
+    WELSH("cy");
+
+    private final String iso639AlphaTwoCode;
+
+    SupportedLanguage(String iso639AlphaTwoCode) {
+        this.iso639AlphaTwoCode = iso639AlphaTwoCode;
+    }
+
+    @Override
+    public String toString() {
+        return iso639AlphaTwoCode;
+    }
+
+    public static SupportedLanguage fromIso639AlphaTwoCode(String iso639AlphaTwoCode) {
+        for (SupportedLanguage supportedLanguage : SupportedLanguage.values()) {
+            if (supportedLanguage.iso639AlphaTwoCode.equals(iso639AlphaTwoCode)) {
+                return supportedLanguage;
+            }
+        }
+        throw new IllegalArgumentException(iso639AlphaTwoCode + " is not a supported ISO 639-1 code");
+    }
+
+}

--- a/model/src/main/java/uk/gov/pay/commons/model/SupportedLanguageJpaConverter.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/SupportedLanguageJpaConverter.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.commons.model;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class SupportedLanguageJpaConverter implements AttributeConverter<SupportedLanguage, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SupportedLanguage supportedLanguage) {
+        return supportedLanguage.toString();
+    }
+
+    @Override
+    public SupportedLanguage convertToEntityAttribute(String supportedLanguage) {
+        return SupportedLanguage.fromIso639AlphaTwoCode(supportedLanguage);
+    }
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/model/SupportedLanguageTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/SupportedLanguageTest.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.commons.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class SupportedLanguageTest {
+
+    @Test
+    public void enMapsToEnglish() {
+        SupportedLanguage result = SupportedLanguage.fromIso639AlphaTwoCode("en");
+        assertThat(result, is(SupportedLanguage.ENGLISH));
+    }
+
+    @Test
+    public void cyMapsToWelsh() {
+        SupportedLanguage result = SupportedLanguage.fromIso639AlphaTwoCode("cy");
+        assertThat(result, is(SupportedLanguage.WELSH));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void frThrowsException() {
+        SupportedLanguage.fromIso639AlphaTwoCode("fr");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void enUpperCaseThrowsException() {
+        SupportedLanguage.fromIso639AlphaTwoCode("EN");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void englishUpperCaseThrowsException() {
+        SupportedLanguage.fromIso639AlphaTwoCode("ENGLISH");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0.0</version>
     <packaging>pom</packaging>
 
-    <name>GOVUK Pay java common repository</name>
+    <name>GOV.UK Pay Java common repository</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -22,6 +22,7 @@
     <modules>
         <module>testing</module>
         <module>utils</module>
+        <module>model</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
Add a new Maven submodule called `model` and add a copy of the `SupportedLanguage` enum in it, so it can be shared across multiple Java projects.

with @DanailMinchev 