### PR TITLE
PP-4226 Share TokenPaymentType across all microservices

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/api/resources/ResourceStrings.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/resources/ResourceStrings.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.commons.api.resources;
+
+class ResourceStrings {
+    private static final String API_OPERATION_NOTES_AUTH = "The Authorisation token needs to be specified in the 'authorization' header ";
+    private static final String API_OPERATION_NOTES_BEARER = "as 'authorization: Bearer YOUR_API_KEY_HERE'";
+    static final String API_OPERATION_NOTES_AUTH_BEARER = API_OPERATION_NOTES_AUTH + API_OPERATION_NOTES_BEARER;
+    static final String API_RESPONSE_ERROR_MSG_CREDENTIALS_REQ = "Credentials are required to access this resource";
+    static final String API_RESPONSE_OK = "OK";
+    static final String API_RESPONSE_CREATED = "Created";
+    static final String API_RESPONSE_ERROR_MSG_BAD_REQUEST = "Bad request";
+    static final String API_RESPONSE_ERROR_MSG_TOO_MANY_REQUESTS = "Too many requests";
+    static final String API_OPERATION_ERROR_MSG_NOT_FOUND = "Not found";
+    static final String API_OPERATION_ERROR_MSG_DOWNSTREAM_SYS_ERROR = "Downstream system error";
+}

--- a/model/src/main/java/uk/gov/pay/commons/model/TokenPaymentType.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/TokenPaymentType.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.commons.model;
+
+public enum TokenPaymentType {
+    CARD("Card Payment"), DIRECT_DEBIT("Direct Debit Payment");
+
+    private String friendlyName;
+
+    TokenPaymentType(String friendlyName) {
+        this.friendlyName = friendlyName;
+    }
+
+    public static TokenPaymentType fromString(final String type) {
+        try {
+            return TokenPaymentType.valueOf(type);
+        } catch (Exception e) {
+            return CARD;
+        }
+    }
+
+    public String getFriendlyName() {
+        return this.friendlyName;
+    }
+}

--- a/model/src/main/java/uk/gov/pay/commons/model/directdebit/agreement/AgreementType.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/directdebit/agreement/AgreementType.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.commons.model.directdebit.agreement;
+
+public enum AgreementType {
+    ON_DEMAND,
+    ONE_OFF
+}

--- a/model/src/main/java/uk/gov/pay/commons/model/directdebit/agreement/MandateType.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/directdebit/agreement/MandateType.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.commons.model.directdebit.agreement;
+
+public enum MandateType {
+    ON_DEMAND,
+    ONE_OFF
+}

--- a/model/src/test/java/uk/gov/pay/commons/model/TokenPaymentTypeTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/TokenPaymentTypeTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.commons.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class TokenPaymentTypeTest {
+
+    @Test
+    public void cardFromStringMapsToCard() {
+        TokenPaymentType result = TokenPaymentType.fromString("CARD");
+        assertThat(result, is(TokenPaymentType.CARD));
+    }
+
+    @Test
+    public void direct_debitFromStringMapsToDirectDebit() {
+        TokenPaymentType result = TokenPaymentType.fromString("DIRECT_DEBIT");
+        assertThat(result, is(TokenPaymentType.DIRECT_DEBIT));
+    }
+
+    @Test
+    public void cashMapsToCard() {
+        TokenPaymentType result = TokenPaymentType.fromString("CASH");
+        assertThat(result, is(TokenPaymentType.CARD));
+    }
+
+    @Test
+    public void cardGetFriendlyNameMapsToCardPayment() {
+        String result = TokenPaymentType.fromString("CARD").getFriendlyName();
+        assertThat(result, is("Card Payment"));
+    }
+
+    @Test
+    public void direct_debitGetFriendlyNameMapsToDirectDebitPayment() {
+        String result = TokenPaymentType.fromString("DIRECT_DEBIT").getFriendlyName();
+        assertThat(result, is("Direct Debit Payment"));
+    }
+}


### PR DESCRIPTION
adds Enums
- TokenPaymentType & unit test,
- AgreementType, 
- MandateType
- new class ResourceStrings for reuse in place of hardcoded strings in Resources
We want Types to be moved here for consistency, remove duplication of code and tests and allow sharing between common Types. We also want to replace hardcoded Strings in PublicApi. 

e.g TokenPaymentType is used in both PublicApi and PublicAuth. Once we have this we will update the version used in those microservices and remove the Types from them.


Author: @cobainc0