### PR TITLE
PP-4248 In utils module, upgrade EclipseLink from 2.6.4 to 2.7.3

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <dropwizard.version>1.3.5</dropwizard.version>
-        <eclipselink.version>2.6.4</eclipselink.version>
+        <eclipselink.version>2.7.3</eclipselink.version>
     </properties>
 
     <dependencyManagement>
@@ -33,8 +33,9 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <version>${eclipselink.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/utils/src/main/java/uk/gov/pay/commons/utils/xray/XRayHttpClientFilter.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/xray/XRayHttpClientFilter.java
@@ -6,7 +6,6 @@ import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Segment;
 import com.amazonaws.xray.entities.Subsegment;
 import com.amazonaws.xray.entities.TraceHeader;
-import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Also switch to just depending on `org.eclipse.persistence.jpa` rather than the full EclipseLink because we only use the JPA functionality.

Set the Maven dependency scope to `compile`, in line with the EclipseLink documentation.

See https://wiki.eclipse.org/EclipseLink/Maven for details.

Remove an unused EclipseLink import in `XRayHttpClientFilter`.