### PR TITLE
PP-4474: Import postgres container handling code from adminusers

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -14,6 +14,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <docker-client.version>8.14.5</docker-client.version>
         <pact.version>3.5.24</pact.version>
         <mockserver.version>5.5.0</mockserver.version>
     </properties>
@@ -38,6 +39,11 @@
             <groupId>javax.json</groupId>
             <artifactId>javax.json-api</artifactId>
             <version>1.1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-client</artifactId>
+            <version>${docker-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresContainer.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresContainer.java
@@ -1,0 +1,139 @@
+package uk.gov.pay.commons.testing.db;
+
+import com.google.common.base.Stopwatch;
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.LogStream;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Integer.parseInt;
+import static java.util.stream.Collectors.joining;
+
+public class PostgresContainer {
+
+    private static final Logger logger = LoggerFactory.getLogger(PostgresContainer.class);
+
+    private final String containerId;
+    private final int port;
+    private DockerClient docker;
+    private String host;
+    private volatile boolean stopped = false;
+    private String dbPassword;
+    private String dbUsername;
+
+    private static final int DB_TIMEOUT_SEC = 15;
+    private static final String INTERNAL_PORT = "5432";
+
+    public PostgresContainer(DockerClient docker, String imageName, String dbUsername, String dbPassword) throws InterruptedException, IOException, ClassNotFoundException, DockerException {
+        Class.forName("org.postgresql.Driver");
+
+        this.docker = docker;
+        this.dbPassword = dbPassword;
+        this.dbUsername = dbUsername;
+
+        failsafeDockerPull(docker, imageName);
+        docker.listImages(DockerClient.ListImagesParam.create("name", imageName));
+
+        final HostConfig hostConfig = HostConfig.builder().logConfig(LogConfig.create("json-file")).publishAllPorts(true).build();
+        ContainerConfig containerConfig = ContainerConfig.builder()
+                .image(imageName)
+                .hostConfig(hostConfig)
+                .env("POSTGRES_USER=" + dbUsername, "POSTGRES_PASSWORD=" + dbPassword)
+                .build();
+        containerId = docker.createContainer(containerConfig).id();
+        docker.startContainer(containerId);
+        port = hostPortNumber(docker.inspectContainer(containerId));
+        registerShutdownHook();
+        waitForPostgresToStart();
+    }
+
+    public PostgresContainer() throws InterruptedException, IOException, ClassNotFoundException, DockerCertificateException, DockerException {
+        this(DefaultDockerClient.fromEnv().build(), "govukpay/postgres:9.6.6", "postgres", "mysecretpassword");
+    }
+
+    public String getUsername() {
+        return dbUsername;
+    }
+
+    public String getPassword() {
+        return dbPassword;
+    }
+
+    public String getConnectionUrl() {
+        return "jdbc:postgresql://" + docker.getHost() + ":" + port + "/";
+    }
+
+    private void failsafeDockerPull(DockerClient docker, String image) {
+        try {
+            docker.pull(image);
+            docker.pull(image);
+        } catch (Exception e) {
+            logger.error("Docker image " + image + " could not be pulled from DockerHub", e);
+        }
+    }
+
+    private static int hostPortNumber(ContainerInfo containerInfo) {
+        List<PortBinding> portBindings = containerInfo.networkSettings().ports().get(INTERNAL_PORT + "/tcp");
+        logger.info("Postgres host port: {}", portBindings.stream().map(PortBinding::hostPort).collect(joining(", ")));
+        return parseInt(portBindings.get(0).hostPort());
+    }
+
+    private void registerShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread(this::stop));
+    }
+
+    private void waitForPostgresToStart() throws DockerException, InterruptedException, IOException {
+        Stopwatch timer = Stopwatch.createStarted();
+        boolean succeeded = false;
+        while (!succeeded && timer.elapsed(TimeUnit.SECONDS) < DB_TIMEOUT_SEC) {
+            Thread.sleep(500);
+            succeeded = checkPostgresConnection();
+        }
+        if (!succeeded) {
+            throw new RuntimeException("Postgres did not start in " + DB_TIMEOUT_SEC + " seconds.");
+        }
+        logger.info("Postgres docker container started in {}.", timer.elapsed(TimeUnit.MILLISECONDS));
+    }
+
+    private boolean checkPostgresConnection() throws IOException {
+
+        Properties props = new Properties();
+        props.setProperty("user", this.dbUsername);
+        props.setProperty("password", this.dbPassword);
+
+        try (Connection connection = DriverManager.getConnection(getConnectionUrl(), props)) {
+            return true;
+        } catch (Exception except) {
+            return false;
+        }
+    }
+
+    public void stop() {
+        if (stopped) {
+            return;
+        }
+        try {
+            stopped = true;
+            System.out.println("Killing postgres container with ID: " + containerId);
+            LogStream logs = docker.logs(containerId, DockerClient.LogsParam.stdout(), DockerClient.LogsParam.stderr());
+            System.out.println("Killed container logs:\n");
+            logs.attach(System.out, System.err);
+            docker.stopContainer(containerId, 5);
+            docker.removeContainer(containerId);
+        } catch (DockerException | InterruptedException | IOException e) {
+            System.err.println("Could not shutdown " + containerId);
+            e.printStackTrace();
+        }
+    }
+}

--- a/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresDockerRule.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresDockerRule.java
@@ -11,15 +11,16 @@ import org.junit.runners.model.Statement;
 import java.io.IOException;
 
 public class PostgresDockerRule implements TestRule {
-
-    private static PostgresContainer container;
+    private PostgresContainer container;
 
     public PostgresDockerRule() {
         startPostgresIfNecessary();
     }
 
     public String getConnectionUrl() {
-        return container.getConnectionUrl();
+        synchronized(container) {
+            return container.getConnectionUrl();
+        }
     }
 
     @Override
@@ -28,26 +29,34 @@ public class PostgresDockerRule implements TestRule {
     }
 
     private void startPostgresIfNecessary() {
-        try {
-            if (container == null) {
-                container = new PostgresContainer();
+        synchronized(container) {
+            try {
+                if (container == null) {
+                    container = new PostgresContainer();
+                }
+            } catch (DockerCertificateException | InterruptedException | DockerException | IOException | ClassNotFoundException e) {
+                throw new RuntimeException(e);
             }
-        } catch (DockerCertificateException | InterruptedException | DockerException | IOException | ClassNotFoundException e) {
-            throw new RuntimeException(e);
         }
     }
 
     public String getUsername() {
-        return container.getUsername();
+        synchronized(container) {
+            return container.getUsername();
+        }
     }
 
     public String getPassword() {
-        return container.getPassword();
+        synchronized(container) {
+            return container.getPassword();
+        }
     }
 
     public void stop() {
-        container.stop();
-        container = null;
+        synchronized(container) {
+            container.stop();
+            container = null;
+        }
     }
 
     public String getDriverClass() {

--- a/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresDockerRule.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresDockerRule.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.commons.testing.db;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+import com.spotify.docker.client.exceptions.DockerException;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.io.IOException;
+
+public class PostgresDockerRule implements TestRule {
+
+    private static PostgresContainer container;
+
+    public PostgresDockerRule() {
+        startPostgresIfNecessary();
+    }
+
+    public String getConnectionUrl() {
+        return container.getConnectionUrl();
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return statement;
+    }
+
+    private void startPostgresIfNecessary() {
+        try {
+            if (container == null) {
+                container = new PostgresContainer();
+            }
+        } catch (DockerCertificateException | InterruptedException | DockerException | IOException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getUsername() {
+        return container.getUsername();
+    }
+
+    public String getPassword() {
+        return container.getPassword();
+    }
+
+    public void stop() {
+        container.stop();
+        container = null;
+    }
+
+    public String getDriverClass() {
+        return "org.postgresql.Driver";
+    }
+}


### PR DESCRIPTION
We have copies of this code in all our projects for bringing up and tearing
down a postgres container in order to run tests. Bring it into our central
testing library and then share it back out.

See https://github.com/alphagov/pay-adminusers/pull/290 for an example of what this replaces and how it would be used