### PR TITLE
BAU: Add a JSON parser implementation

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -41,6 +41,11 @@
             <version>1.1.4</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+        <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
             <version>${docker-client.version}</version>


### PR DESCRIPTION
Just importing the javax.json API is not enough - we also need an
implmentation.