### PR TITLE
PP-4573: Add a version constraint to maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
For some reason we didn't pin this plugin to a version like we do with all our
others.