### PR TITLE
Change version number scheme to be timestamp rather than Git SHA

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,8 @@ pipeline {
                     string(credentialsId: 'bintray_username', variable: 'BINTRAY_USERNAME'),
                     string(credentialsId: 'bintray_api_key', variable: 'BINTRAY_APIKEY')]
             ) {
-              sh "mvn versions:set -DnewVersion=1.0.0-${gitCommit()}"
+              def timestamp = new Date().format("yyyyMMddHHmmss", TimeZone.getTimeZone('UTC'))
+              sh "mvn versions:set -DnewVersion=${timestamp}"
               sh 'mvn --settings settings.xml -Dbintray.username=${BINTRAY_USERNAME} -Dbintray.apiKey=${BINTRAY_APIKEY} deploy'
             }
           } else {


### PR DESCRIPTION
Change the version numbering scheme from being like 1.0.0-a4ac0cce47da65f86c580f856f60f98a62e88ee9 (where a4ac0cce47da65f86c580f856f60f98a62e88ee9 is the Git SHA of the commit) to being like 20190108160351 where 20190108160351 is a timestamp in the form yyyyMMddHHmmss.

This makes it easy to compare version numbers to see which is newer and also means that newer versions sort lexicographically after older versions.