### PR TITLE
PP-4595 ISO instant date/time formatter with millisecond precision

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatter.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatter.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.commons.model;
+
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
+
+public class ApiResponseDateTimeFormatter {
+
+    public static final DateTimeFormatter ISO_INSTANT_MILLISECOND_PRECISION =
+            new DateTimeFormatterBuilder()
+                    .appendInstant(3)
+                    .toFormatter(Locale.ENGLISH)
+                    .withZone(ZoneOffset.UTC);
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatterTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatterTest.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.commons.model;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static java.time.Month.OCTOBER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+public class ApiResponseDateTimeFormatterTest {
+
+    @Test
+    public void shouldConvertUtcToIsoStringWithMillisecondPrecision() {
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
+                LocalTime.of(7, 28, 0, 123456789), ZoneOffset.UTC);
+
+        String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
+
+        assertThat(result, is("2015-10-21T07:28:00.123Z"));
+    }
+
+    @Test
+    public void shouldConvertNonUtcToIsoStringWithMillisecondPrecision() {
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
+                LocalTime.of(7, 28, 0, 123456789), ZoneId.of("America/Los_Angeles"));
+
+        String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
+
+        assertThat(result, is("2015-10-21T14:28:00.123Z"));
+    }
+
+    @Test
+    public void shouldConvertExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
+                LocalTime.of(7, 28, 0), ZoneOffset.UTC);
+
+        String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
+
+        assertThat(result, is("2015-10-21T07:28:00.000Z"));
+    }
+
+}


### PR DESCRIPTION
We use `DateTimeFormatter.ISO_INSTANT.withZone(UTC)` to format a lot of the timestamps we put in API responses, which produces strings like `"2015-10-21T07:28:00.123Z"`. The fractional part, if present, will have either three, six or nine digits, depending on the precision available.

When one asks Java 8 for the current time, it always returns the time with millisecond precision, even if the underlying system clock can do better. Java 9 and above don’t have this limitation
and will return higher accuracy if the system clock offers it (see https://bugs.openjdk.java.net/browse/JDK-8068730 for details). On Linux and macOS, this usually means microsecond precision.

Therefore, when `DateTimeFormatter.ISO_INSTANT.withZone(UTC)` is used to format the current time on Java 8, the resulting string has three digits after the decimal point. When it’s used on Java 9 on Linux or macOS, it will have six digits. This means that the timestamps we put into API responses — many of which are the current time or a stored past current time — may vary depending on the Java version.

Eliminate this difference by introducing a `DateTimeFormatter` that always uses millisecond precision. If this `DateTimeFormatter` is used throughout the system, then there will be no change to the timestamps in our API responses when we upgrade to Java 11.

Note that this new `DateTimeFormatter` has one slight behaviour change: if `DateTimeFormatter.ISO_INSTANT.withZone(UTC)` is asked to format a time that’s exactly on the second, it will not include a fractional component (e.g. `"2015-10-21T07:28:00Z"`). The new `DateTimeFormatter` always includes a fractional component (e.g. `"2015-10-21T07:28:00.000Z"`). This actually makes things more consistent, so we’re happy with this change.