### PR TITLE
PP-4612 Add Testcontainers PostgreSQL dependency

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -102,5 +102,11 @@
             <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.10.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Testcontainers is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container

Testcontainers PostgreSQL can be used as replacement for custom PostgreSQL container https://github.com/alphagov/pay-java-commons/tree/fba5b7543e5565f715ef9b8bc50d580760c4b816/testing/src/main/java/uk/gov/pay/commons/testing/db