### PR TITLE
BAU: Change version number scheme to be more Mavenesque

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
                     string(credentialsId: 'bintray_api_key', variable: 'BINTRAY_APIKEY')]
             ) {
               def timestamp = new Date().format("yyyyMMddHHmmss", TimeZone.getTimeZone('UTC'))
-              sh "mvn versions:set -DnewVersion=${timestamp}"
+              sh "mvn versions:set -DnewVersion=1.0.${timestamp}"
               sh 'mvn --settings settings.xml -Dbintray.username=${BINTRAY_USERNAME} -Dbintray.apiKey=${BINTRAY_APIKEY} deploy'
             }
           } else {


### PR DESCRIPTION
Change the version number scheme from being like 20190115100435 to being like 1.0.20190115100435 because it’s more in line with Maven conventions and will hopefully make Dependabot less confused about what the latest version is.