### PR TITLE
PP-4616: Add support for waiting for database availability on startup

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -43,6 +43,11 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jdbi</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-core</artifactId>
         </dependency>
@@ -61,6 +66,13 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-sql-postgres</artifactId>
+        </dependency>
+        <!-- Test dependencies go below here -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.23.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResource.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResource.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.commons.utils.startup;
+
+interface ApplicationStartupDependentResource {
+    boolean isAvailable();
+}

--- a/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResourceChecker.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResourceChecker.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.commons.utils.startup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+
+class ApplicationStartupDependentResourceChecker {
+
+    private static final int PROGRESSIVE_SECONDS_TO_WAIT = 5;
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class);
+
+    private final ApplicationStartupDependentResource applicationStartupDependentResource;
+    private final Consumer<Duration> waiter;
+
+    ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource, Consumer<Duration> waiter) {
+        this.applicationStartupDependentResource = applicationStartupDependentResource;
+        this.waiter = waiter;
+    }
+
+    void checkAndWaitForResource() {
+        long timeToWait = 0;
+        while(!applicationStartupDependentResource.isAvailable()) {
+            timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;
+            logger.info("Waiting for {} seconds until {} is available ...", timeToWait, applicationStartupDependentResource);
+            waiter.accept(Duration.ofSeconds(timeToWait));
+        }
+        logger.info("{} available.", applicationStartupDependentResource);
+    }
+
+}

--- a/utils/src/main/java/uk/gov/pay/commons/utils/startup/DatabaseStartupResource.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/startup/DatabaseStartupResource.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.commons.utils.startup;
+
+import io.dropwizard.db.DataSourceFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static java.lang.String.format;
+
+public class DatabaseStartupResource implements ApplicationStartupDependentResource {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseStartupResource.class);
+
+    private final String databaseUrl;
+    private final String databaseUser;
+    private final String databasePassword;
+
+    DatabaseStartupResource(DataSourceFactory dataSourceFactory) {
+        databaseUrl = dataSourceFactory.getUrl();
+        databaseUser = dataSourceFactory.getUser();
+        databasePassword = dataSourceFactory.getPassword();
+    }
+
+    public boolean isAvailable() {
+        try {
+            DriverManager.getConnection(databaseUrl, databaseUser, databasePassword).close();
+            return true;
+        } catch (SQLException e) {
+            logger.warn("Unable to connect to database: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return format("DatabaseStartupResource[url=%s, user=%s]", databaseUrl, databaseUser);
+    }
+}

--- a/utils/src/test/java/uk/gov/pay/commons/utils/startup/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/startup/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.commons.utils.startup;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
+
+    @InjectMocks
+    ApplicationStartupDependentResourceChecker applicationStartupDependentResourceChecker;
+
+    @Mock
+    DatabaseStartupResource mockApplicationStartupDependentResource;
+    @Mock
+    Consumer<Duration> mockWaiter;
+
+    private Appender mockAppender;
+
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @Before
+    public void setup() {
+        mockAppender = mock(Appender.class);
+        ((Logger) LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class)).addAppender(mockAppender);
+    }
+
+    @Test
+    public void start_ShouldWaitAndLogUntilDatabaseIsAccessible() {
+
+        when(mockApplicationStartupDependentResource.toString()).thenReturn("DatabaseStartupResource[url=mock, user=mock]");
+        when(mockApplicationStartupDependentResource.isAvailable())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        applicationStartupDependentResourceChecker.checkAndWaitForResource();
+
+        verify(mockApplicationStartupDependentResource, times(2)).isAvailable();
+        verify(mockWaiter).accept(Duration.ofSeconds(5));
+
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> allValues = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(allValues.get(0).getFormattedMessage(), is("Waiting for 5 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(allValues.get(1).getFormattedMessage(), is("DatabaseStartupResource[url=mock, user=mock] available."));
+    }
+
+    @Test
+    public void start_ShouldProgressivelyIncrementSleepingTimeBetweenChecksForDBAccessibility() {
+        when(mockApplicationStartupDependentResource.toString()).thenReturn("DatabaseStartupResource[url=mock, user=mock]");
+        when(mockApplicationStartupDependentResource.isAvailable())
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(false)
+                .thenReturn(true);
+
+        applicationStartupDependentResourceChecker.checkAndWaitForResource();
+
+        verify(mockApplicationStartupDependentResource, times(4)).isAvailable();
+        verify(mockWaiter).accept(Duration.ofSeconds(5));
+        verify(mockWaiter).accept(Duration.ofSeconds(10));
+        verify(mockWaiter).accept(Duration.ofSeconds(15));
+        verify(mockAppender, times(4)).doAppend(loggingEventArgumentCaptor.capture());
+
+        List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logStatement.get(0).getFormattedMessage(), is("Waiting for 5 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(logStatement.get(1).getFormattedMessage(), is("Waiting for 10 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(logStatement.get(2).getFormattedMessage(), is("Waiting for 15 seconds until DatabaseStartupResource[url=mock, user=mock] is available ..."));
+        assertThat(logStatement.get(3).getFormattedMessage(), is("DatabaseStartupResource[url=mock, user=mock] available."));
+    }
+}


### PR DESCRIPTION
Code imported from `pay-publicauth`.

This code is duplicated in all our Java microservices with databases. It allows
the apps to pause startup until their databases become available.

Example usage:

    new ApplicationStartupDependentResourceChecker(new DatabaseStartupResource(conf.getDataSourceFactory()), duration -> {
        try { Thread.sleep(duration.getNano() / 1000); } catch (InterruptedException ignored) { }
    }).checkAndWaitForResource();