### PR TITLE
PP-4616: Make ApplicationStartupDependentResourceChecker public

### DIFF
--- a/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResourceChecker.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResourceChecker.java
@@ -6,7 +6,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.function.Consumer;
 
-class ApplicationStartupDependentResourceChecker {
+public class ApplicationStartupDependentResourceChecker {
 
     private static final int PROGRESSIVE_SECONDS_TO_WAIT = 5;
     private static final Logger logger = LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class);
@@ -14,12 +14,12 @@ class ApplicationStartupDependentResourceChecker {
     private final ApplicationStartupDependentResource applicationStartupDependentResource;
     private final Consumer<Duration> waiter;
 
-    ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource, Consumer<Duration> waiter) {
+    public ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource, Consumer<Duration> waiter) {
         this.applicationStartupDependentResource = applicationStartupDependentResource;
         this.waiter = waiter;
     }
 
-    void checkAndWaitForResource() {
+    public void checkAndWaitForResource() {
         long timeToWait = 0;
         while(!applicationStartupDependentResource.isAvailable()) {
             timeToWait += PROGRESSIVE_SECONDS_TO_WAIT;


### PR DESCRIPTION
If we want apps to use this class, having it package-private isn't going to help.