### PR TITLE
PP-4616: Make DatabaseStartupResource constructor public

### DIFF
--- a/utils/src/main/java/uk/gov/pay/commons/utils/startup/DatabaseStartupResource.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/startup/DatabaseStartupResource.java
@@ -17,7 +17,7 @@ public class DatabaseStartupResource implements ApplicationStartupDependentResou
     private final String databaseUser;
     private final String databasePassword;
 
-    DatabaseStartupResource(DataSourceFactory dataSourceFactory) {
+    public DatabaseStartupResource(DataSourceFactory dataSourceFactory) {
         databaseUrl = dataSourceFactory.getUrl();
         databaseUser = dataSourceFactory.getUser();
         databasePassword = dataSourceFactory.getPassword();


### PR DESCRIPTION
If we want people to use this, it helps if they can access it.