### PR TITLE
PP-4616: Add a convenience constructor to ApplicationStartupDependentResourceChecker

### DIFF
--- a/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResourceChecker.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/startup/ApplicationStartupDependentResourceChecker.java
@@ -14,6 +14,15 @@ public class ApplicationStartupDependentResourceChecker {
     private final ApplicationStartupDependentResource applicationStartupDependentResource;
     private final Consumer<Duration> waiter;
 
+    public ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource) {
+        this(applicationStartupDependentResource, duration -> {
+            try {
+                Thread.sleep(duration.toMillis());
+            } catch (InterruptedException ignored) {
+            }
+        });
+    }
+
     public ApplicationStartupDependentResourceChecker(ApplicationStartupDependentResource applicationStartupDependentResource, Consumer<Duration> waiter) {
         this.applicationStartupDependentResource = applicationStartupDependentResource;
         this.waiter = waiter;

--- a/utils/src/test/java/uk/gov/pay/commons/utils/startup/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/startup/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
@@ -26,9 +25,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
-
-    @InjectMocks
-    ApplicationStartupDependentResourceChecker applicationStartupDependentResourceChecker;
+    private ApplicationStartupDependentResourceChecker applicationStartupDependentResourceChecker;
 
     @Mock
     DatabaseStartupResource mockApplicationStartupDependentResource;
@@ -44,6 +41,8 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     public void setup() {
         mockAppender = mock(Appender.class);
         ((Logger) LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class)).addAppender(mockAppender);
+
+        applicationStartupDependentResourceChecker = new ApplicationStartupDependentResourceChecker(mockApplicationStartupDependentResource, mockWaiter);
     }
 
     @Test


### PR DESCRIPTION
It's only the tests which need to pass in a custom 'waiter' to this class, so
provide a constructor that supplies a sensible default implementation for the
real consumers to use, making their lives easier.