### PR TITLE
PP-4606: Log request IDs more accurately; add response timing metrics

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -67,6 +67,11 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-sql-postgres</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <version>4.0.5</version>
+        </dependency>
         <!-- Test dependencies go below here -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/utils/src/main/java/uk/gov/pay/commons/utils/logging/LoggingFilter.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/logging/LoggingFilter.java
@@ -16,6 +16,10 @@ import java.util.concurrent.TimeUnit;
 public class LoggingFilter implements Filter {
 
     private static final Logger logger = LoggerFactory.getLogger(LoggingFilter.class);
+    /**
+     * This key should match the value in our logging configuration e.g. %X{X-Request-Id:-(none)}
+     */
+    private static final String MDC_REQUEST_ID_KEY = "X-Request-Id";
 
     @Override
     public void init(FilterConfig filterConfig) { }
@@ -27,10 +31,13 @@ public class LoggingFilter implements Filter {
 
         String requestURL = httpRequest.getRequestURI();
         String requestMethod = httpRequest.getMethod();
-        String requestIdHeader = httpRequest.getHeader("X-Request-Id");
+        String requestId = httpRequest.getHeader("X-Request-Id");
 
-        // The key passed to MDC here should match the value in our logging configuration
-        MDC.put("X-Request-Id", requestIdHeader == null ? "(null)" : requestIdHeader);
+        if (requestId == null) {
+            MDC.remove(MDC_REQUEST_ID_KEY);
+        } else {
+            MDC.put(MDC_REQUEST_ID_KEY, requestId);
+        }
 
         logger.info("{} to {} began", requestMethod, requestURL);
         try {

--- a/utils/src/test/java/uk/gov/pay/commons/utils/logging/LoggingFilterTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/logging/LoggingFilterTest.java
@@ -60,51 +60,41 @@ public class LoggingFilterTest {
 
     @Test
     public void shouldLogEntryAndExitPointsOfEndPoints() throws Exception {
-        String requestUrl = "/publicauth-request";
-        String requestMethod = "GET";
-
-        when(mockRequest.getRequestURI()).thenReturn(requestUrl);
-        when(mockRequest.getMethod()).thenReturn(requestMethod);
+        when(mockRequest.getRequestURI()).thenReturn("/publicauth-request");
+        when(mockRequest.getMethod()).thenReturn("GET");
 
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("%s to %s began", requestMethod, requestUrl)));
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("GET to /publicauth-request began"));
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("%s to %s ended - total time ", requestMethod, requestUrl)));
+        assertThat(endLogMessage, containsString("GET to /publicauth-request ended - total time "));
         assertThat(endLogMessage, matchesRegex(".*total time \\d+ms"));
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
     }
 
     @Test
     public void shouldLogEntryAndExitPointsEvenIfRequestIdDoesNotExist() throws Exception {
-
-        String requestUrl = "/publicauth-request";
-        String requestMethod = "GET";
-
-        when(mockRequest.getRequestURI()).thenReturn(requestUrl);
-        when(mockRequest.getMethod()).thenReturn(requestMethod);
+        when(mockRequest.getRequestURI()).thenReturn("/publicauth-request");
+        when(mockRequest.getMethod()).thenReturn("GET");
 
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
 
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("%s to %s began", requestMethod, requestUrl)));
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("GET to /publicauth-request began"));
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("%s to %s ended - total time ", requestMethod, requestUrl)));
+        assertThat(endLogMessage, containsString("GET to /publicauth-request ended - total time "));
         verify(mockFilterChain).doFilter(mockRequest, mockResponse);
     }
 
     @Test
     public void shouldLogEntryAndExitPointsEvenWhenFilterChainingThrowsException() throws Exception {
-        String requestUrl = "/publicauth-url-with-exception";
-        String requestMethod = "GET";
-
-        when(mockRequest.getRequestURI()).thenReturn(requestUrl);
-        when(mockRequest.getMethod()).thenReturn(requestMethod);
+        when(mockRequest.getRequestURI()).thenReturn("/publicauth-url-with-exception");
+        when(mockRequest.getMethod()).thenReturn("GET");
 
         IOException exception = new IOException("Failed request");
         doThrow(exception).when(mockFilterChain).doFilter(mockRequest, mockResponse);
@@ -114,12 +104,12 @@ public class LoggingFilterTest {
         verify(mockAppender, times(3)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("%s to %s began", requestMethod, requestUrl)));
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("GET to /publicauth-url-with-exception began"));
         assertThat(loggingEvents.get(1).getFormattedMessage(), is(format("Exception - %s", exception.getMessage())));
         assertThat(loggingEvents.get(1).getLevel(), is(Level.ERROR));
         assertThat(loggingEvents.get(1).getThrowableProxy().getMessage(), is("Failed request"));
         String endLogMessage = loggingEvents.get(2).getFormattedMessage();
-        assertThat(endLogMessage, containsString(format("%s to %s ended - total time ", requestMethod, requestUrl)));
+        assertThat(endLogMessage, containsString("GET to /publicauth-url-with-exception ended - total time "));
         assertThat(endLogMessage, matchesRegex(".*total time \\d+ms"));
     }
 

--- a/utils/src/test/java/uk/gov/pay/commons/utils/logging/LoggingFilterTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/logging/LoggingFilterTest.java
@@ -24,7 +24,9 @@ import java.util.List;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -129,7 +131,7 @@ public class LoggingFilterTest {
 
         when(mockRequest.getHeader("X-Request-Id")).thenReturn(null);
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
-        assertThat(MDC.get("X-Request-Id"), is("(null)"));
+        assertThat(MDC.get("X-Request-Id"), is(nullValue()));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
- Stop making up a placeholder request ID for requests which have none. If you want to log something in place of a missing value, make use of the fallback default behaviour of the `%X` log format placeholder when formatting log messages, i.e. `%X{Request-Id:-(none)}`

- Add optional support for recording response timing histograms using `dropwizard-metrics` (taken from `pay-cardid`'s `LoggingFilter`