### PR TITLE
PP-4597 Added JSON serializer for ZonedDateTime

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeSerializer.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeSerializer.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ApiResponseDateTimeSerializer extends StdSerializer<ZonedDateTime> {
+
+    public ApiResponseDateTimeSerializer() {
+        this(null);
+    }
+
+    private ApiResponseDateTimeSerializer(Class<ZonedDateTime> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider sp) throws IOException {
+        gen.writeString(ISO_INSTANT_MILLISECOND_PRECISION.format(value));
+    }
+}

--- a/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeSerializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeSerializerTest.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.time.ZonedDateTime;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class ApiResponseDateTimeSerializerTest {
+    private final ApiResponseDateTimeSerializer serializer = new ApiResponseDateTimeSerializer();
+
+    @Test
+    public void shouldSerializeWithMillisecondPrecision() throws IOException {
+        ZonedDateTime testValue = ZonedDateTime.parse("2019-01-29T11:34:53.849012345Z");
+        Writer jsonWriter = new StringWriter();
+        JsonGenerator jsonGenerator = new JsonFactory().createGenerator(jsonWriter);
+        final SerializerProvider serializerProvider = new ObjectMapper().getSerializerProvider();
+        serializer.serialize(testValue, jsonGenerator, serializerProvider);
+        jsonGenerator.flush();
+        final String actual = jsonWriter.toString();
+        assertEquals("\"2019-01-29T11:34:53.849Z\"", actual);
+    }
+}


### PR DESCRIPTION
- To keep our ZDT external representation consistent, we created a serializer
that will format ZDT with millisecond precision. This will ease the
transition to Java 11