### PR TITLE
PP-4597 Added JSON deserializer for ZonedDateTime

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeDeserializer.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeDeserializer.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
+
+/**
+ * Custom JSON Deserializer that will try to parse a String into a ZonedDateTime
+ */
+public class ApiResponseDateTimeDeserializer extends StdDeserializer<ZonedDateTime> {
+
+    public ApiResponseDateTimeDeserializer() {
+        this(null);
+    }
+
+    public ApiResponseDateTimeDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public ZonedDateTime deserialize(JsonParser jsonparser, DeserializationContext context) throws IOException {
+        final String dateString = jsonparser.getText();
+        return ZonedDateTime.parse(dateString, ISO_ZONED_DATE_TIME).withZoneSameInstant(UTC);
+    }
+}

--- a/model/src/main/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatter.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatter.java
@@ -5,6 +5,11 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
 
+/**
+ * Custom ZonedDateTime formatter that will format to millisecond precision.
+ * This will be padding with zeroes missing milliseconds and will drop
+ * anything after the milliseconds field
+ */
 public class ApiResponseDateTimeFormatter {
 
     public static final DateTimeFormatter ISO_INSTANT_MILLISECOND_PRECISION =

--- a/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeDeserializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeDeserializerTest.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.commons.api.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+
+public class ApiResponseDateTimeDeserializerTest {
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void before() {
+        objectMapper = new ObjectMapper();
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(ZonedDateTime.class, new ApiResponseDateTimeDeserializer());
+        objectMapper.registerModule(simpleModule);
+    }
+
+    @Test
+    public void shouldDeserializeValidString() throws IOException {
+        String testValue = "{\"created_date\":\"2019-01-29T11:34:53.849012345Z\"}";
+
+        RequestDateTimeJsonTest actual = objectMapper.readValue(testValue, RequestDateTimeJsonTest.class);
+        ZonedDateTime expected = ZonedDateTime.parse("2019-01-29T11:34:53.849012345Z");
+        assertEquals(expected, actual.getCreatedDate());
+    }
+
+    @Test
+    public void shouldDeserializeToNull() throws IOException {
+        String testValue = "{\"created_date\":null}";
+
+        RequestDateTimeJsonTest response = objectMapper.readValue(testValue, RequestDateTimeJsonTest.class);
+        assertNull(response.getCreatedDate());
+    }
+
+    @Test(expected = JsonMappingException.class)
+    public void shouldThrowExceptionWhenNullValue() throws IOException {
+        String testValue = "{\"created_date\":\"blah\"}";
+        final RequestDateTimeJsonTest response = objectMapper.readValue(testValue, RequestDateTimeJsonTest.class);
+        assertNull(response.getCreatedDate());
+    }
+}
+
+class RequestDateTimeJsonTest {
+    @JsonProperty(value = "created_date")
+    @JsonDeserialize(using = ApiResponseDateTimeDeserializer.class)
+    private ZonedDateTime createdDate;
+
+    ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+}


### PR DESCRIPTION
- To keep our ZDT internal representation consistent, we created a deserializer
that will parse String into ZonedDateTime. This will make our apps consistent
