### PR TITLE
PP-4790 Get metadata from database login

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -48,6 +48,11 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-core</artifactId>
         </dependency>

--- a/utils/src/main/java/uk/gov/pay/commons/utils/xray/XRaySessionProfiler.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/xray/XRaySessionProfiler.java
@@ -5,10 +5,10 @@ import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Subsegment;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.persistence.internal.databaseaccess.Accessor;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.sessions.DatabaseLogin;
 import org.eclipse.persistence.sessions.Record;
 import org.eclipse.persistence.sessions.Session;
 import org.eclipse.persistence.sessions.SessionProfiler;
@@ -17,18 +17,24 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 public class XRaySessionProfiler implements SessionProfiler {
-    private int profileWeight = SessionProfiler.ALL;
     private static final Logger logger = LoggerFactory.getLogger(XRaySessionProfiler.class);
-    private final AWSXRayRecorder recorder = AWSXRay.getGlobalRecorder();
+    private int profileWeight = SessionProfiler.ALL;
+    private final AWSXRayRecorder recorder;
+
+    // Required by EclipseLink
+    public XRaySessionProfiler() {
+        this.recorder = AWSXRay.getGlobalRecorder();
+    }
+
+    // Used for testing
+    XRaySessionProfiler(AWSXRayRecorder recorder) {
+        this.recorder = recorder;
+    }
 
     @Override
     public void endOperationProfile(String operationName) {
@@ -41,21 +47,23 @@ public class XRaySessionProfiler implements SessionProfiler {
     @Override
     public Object profileExecutionOfQuery(DatabaseQuery databaseQuery, Record record, AbstractSession abstractSession) {
         if (recorder.getCurrentSegmentOptional().isPresent()) {
-            final Optional<Connection> maybeConnection = Optional.ofNullable(abstractSession.getAccessor()).map(Accessor::getConnection);
-            Map<String, Object> databaseMetadata = new HashMap<>();
+            DatabaseLogin databaseLogin = (DatabaseLogin) abstractSession.getDatasourceLogin();
             String hostname = "database";
-            if (maybeConnection.isPresent()) {
-                final Connection connection = maybeConnection.get();
-                databaseMetadata = getMetadata(databaseQuery, connection);
-                hostname = getDatabaseHostName(connection);
+            Map<String, Object> databaseMetadata = new HashMap<>();
+            if (null != databaseLogin) {
+                hostname = getDatabaseHostName(databaseLogin);
+                databaseMetadata = getMetadata(databaseLogin);
             } else {
-                logger.warn("There is no database connection available");
+                logger.warn("No database login available");
             }
 
             Subsegment subsegment = recorder.beginSubsegment(hostname);
             subsegment.putMetadata("monitor_name", databaseQuery.getMonitorName());
             subsegment.putMetadata("calling_class", databaseQuery.getClass().getSimpleName());
             subsegment.setNamespace(Namespace.REMOTE.toString());
+
+            databaseMetadata.put("preparation", databaseQuery.isCallQuery() ? "call" : "statement");
+            databaseMetadata.put("sanitized_query", StringUtils.isEmpty(databaseQuery.getSQLString()) ? "" : databaseQuery.getSQLString());
             subsegment.putAllSql(databaseMetadata);
 
             try {
@@ -69,33 +77,22 @@ public class XRaySessionProfiler implements SessionProfiler {
         }
     }
 
-    private Map<String, Object> getMetadata(DatabaseQuery databaseQuery, Connection connection) {
-        try {
-            Map<String, Object> databaseMetadata = new HashMap<>();
-            DatabaseMetaData metadata = connection.getMetaData();
-            databaseMetadata.put("url", metadata.getURL());
-            databaseMetadata.put("user", metadata.getUserName());
-            databaseMetadata.put("driver_version", metadata.getDriverVersion());
-            databaseMetadata.put("database_type", metadata.getDatabaseProductName());
-            databaseMetadata.put("database_version", metadata.getDatabaseProductVersion());
-            databaseMetadata.put("preparation", databaseQuery.isCallQuery() ? "call" : "statement");
-            databaseMetadata.put("sanitized_query", StringUtils.isEmpty(databaseQuery.getSQLString()) ? "" : databaseQuery.getSQLString());
-            return databaseMetadata;
-        } catch (SQLException exception) {
-            logger.warn("Error getting database connection details.");
-        }
-        return Collections.emptyMap();
+    private Map<String, Object> getMetadata(DatabaseLogin datasourceLogin) {
+        Map<String, Object> databaseMetadata = new HashMap<>();
+        databaseMetadata.put("url", datasourceLogin.getURL());
+        databaseMetadata.put("user", datasourceLogin.getUserName());
+        return databaseMetadata;
     }
 
-    private String getDatabaseHostName(Connection connection) {
+    private String getDatabaseHostName(DatabaseLogin datasourceLogin) {
         try {
-            DatabaseMetaData metadata = connection.getMetaData();
-            String hostname = new URI((new URI(metadata.getURL())).getSchemeSpecificPart()).getHost();
-            return connection.getCatalog() + "@" + hostname;
+            final URI dbURI = new URI((new URI(datasourceLogin.getURL())).getSchemeSpecificPart());
+            String hostname = dbURI.getHost();
+            final String rawPath = dbURI.getPath();
+            String catalogue = rawPath.substring(1);
+            return catalogue + "@" + hostname;
         } catch (URISyntaxException exception) {
             logger.warn("Error parsing database host name.");
-        } catch (SQLException exception) {
-            logger.warn("Error getting database connection details.");
         }
         return "database";
     }

--- a/utils/src/test/java/uk/gov/pay/commons/utils/xray/XRaySessionProfilerTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/xray/XRaySessionProfilerTest.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.commons.utils.xray;
+
+import com.amazonaws.xray.AWSXRayRecorder;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
+import org.eclipse.persistence.internal.sessions.AbstractRecord;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.sessions.DatabaseLogin;
+import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.SessionProfiler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class XRaySessionProfilerTest {
+    @Captor
+    ArgumentCaptor<Map<String, Object>> mapArgumentCaptor;
+
+    private DatabaseQuery mockedQuery = mock(DatabaseQuery.class);
+    private Record mockedRecord = mock(AbstractRecord.class);
+    private AbstractSession mockedSession = mock(AbstractSession.class);
+    private AWSXRayRecorder mockedRecorder = mock(AWSXRayRecorder.class);
+    private Segment mockedSegment = mock(Segment.class);
+    private Subsegment mockedSubSegment = mock(Subsegment.class);
+    private DatabaseLogin loginDetails = new DatabaseLogin();
+    private SessionProfiler xrayProfiler;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        xrayProfiler = new XRaySessionProfiler(mockedRecorder);
+        when(mockedRecorder.getCurrentSegmentOptional()).thenReturn(Optional.of(mockedSegment));
+        when(mockedRecorder.beginSubsegment(anyString())).thenReturn(mockedSubSegment);
+        loginDetails.setURL("jdbc:postgresql://localhost:32788/connector_tests");
+        loginDetails.setUserName("test username");
+        when(mockedSession.getDatasourceLogin()).thenReturn(loginDetails);
+        when(mockedQuery.getMonitorName()).thenReturn("Test Monitor");
+        when(mockedQuery.getSQLString()).thenReturn("SELECT 1");
+        when(mockedQuery.isCallQuery()).thenReturn(false);
+    }
+
+    @Test
+    public void shouldPopulateFieldsForSegment() {
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        xrayProfiler.profileExecutionOfQuery(mockedQuery, mockedRecord, mockedSession);
+
+        verify(mockedRecorder).beginSubsegment(argumentCaptor.capture());
+        verify(mockedSubSegment).putAllSql(mapArgumentCaptor.capture());
+
+        String actualURI = argumentCaptor.getValue();
+
+        assertEquals("connector_tests@localhost", actualURI);
+
+        Map<String, Object> actualSQLMap = mapArgumentCaptor.getValue();
+        assertEquals("statement", actualSQLMap.get("preparation"));
+        assertEquals("test username", actualSQLMap.get("user"));
+        assertEquals("jdbc:postgresql://localhost:32788/connector_tests", actualSQLMap.get("url"));
+        assertEquals("SELECT 1", actualSQLMap.get("sanitized_query"));
+
+        assertEquals(SessionProfiler.ALL, xrayProfiler.getProfileWeight());
+    }
+    
+    @Test
+    public void shouldNotPopulateFieldsWhenNullDatabaseLogin() {
+        when(mockedSession.getDatasourceLogin()).thenReturn(null);
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+
+        xrayProfiler.profileExecutionOfQuery(mockedQuery, mockedRecord, mockedSession);
+
+        verify(mockedRecorder).beginSubsegment(argumentCaptor.capture());
+        verify(mockedSubSegment).putAllSql(mapArgumentCaptor.capture());
+
+        String actualURI = argumentCaptor.getValue();
+
+        assertEquals("database", actualURI);
+
+        Map<String, Object> actualSQLMap = mapArgumentCaptor.getValue();
+        assertEquals("statement", actualSQLMap.get("preparation"));
+
+        assertNull(actualSQLMap.get("user"));
+        assertNull(actualSQLMap.get("url"));
+        assertEquals("SELECT 1", actualSQLMap.get("sanitized_query"));
+
+        assertEquals(SessionProfiler.ALL, xrayProfiler.getProfileWeight());
+    }
+}


### PR DESCRIPTION
- Most of the metadata can be accessed independent of a connected session.
This is done using the DatabaseLogin object. This metadata can be skipped if
not available so we will populate only what we can find.
- We decided to avoid querying if the connection is null, as we observed that
after a database error, all subsequent calls to the profiler were using a
`disconnected` database session. We don't need to use a connection, no matter
what the status, so we will not use it at all.
- Added DropWizard testing to write a small unit test to check that the
properties are set