### PR TITLE
PP-4832: Upgrade postgresql to 9.6.12

### DIFF
--- a/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresContainer.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresContainer.java
@@ -59,7 +59,7 @@ public class PostgresContainer {
     }
 
     public PostgresContainer() throws InterruptedException, IOException, ClassNotFoundException, DockerCertificateException, DockerException {
-        this(DefaultDockerClient.fromEnv().build(), "govukpay/postgres:9.6.11", "postgres", "mysecretpassword");
+        this(DefaultDockerClient.fromEnv().build(), "govukpay/postgres:9.6.12", "postgres", "mysecretpassword");
     }
 
     public String getUsername() {


### PR DESCRIPTION
This isn't yet available in AWS, but we can start testing against it.