### PR TITLE
PP-4951 Add a Millisecond ISO Instant formatter for common use.

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/model/DateTimeFormatters.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/DateTimeFormatters.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.commons.model;
+
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeFormatters {
+    public final static DateTimeFormatter MILLISECOND_ISO_INSTANT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+}

--- a/model/src/test/java/uk/gov/pay/commons/model/DateTimeFormattersTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/DateTimeFormattersTest.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.commons.model;
+
+
+import org.junit.Test;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class DateTimeFormattersTest {
+
+    @Test
+    public void shouldFormatToMillisecondPrecision() {
+        ZonedDateTime aZonedDateTime = ZonedDateTime.of(1969, 7, 20, 20, 18, 4, 111111111, ZoneId.of("UTC"));
+        assertThat(aZonedDateTime.format(DateTimeFormatters.MILLISECOND_ISO_INSTANT_FORMATTER), is("1969-07-20T20:18:04.111Z"));
+    }
+
+}


### PR DESCRIPTION
This formatter can be used to ensure dates are formatted consistently to
millisecond precision, for example when creating expected string values for tests.

Whilst preparing Direct Debit Connector for Java 11 it is necessary to format the expected date string for tests to millisecond precision (currently using `DateTimeFormatter.ISO_INSTANT` which uses the level of precision offered by the system, on my local machine this is to nanoseconds). In anticipation that this will be useful in other projects I've added it here to pay-commons.