### PR TITLE
PP-4884 Add annotation and validation for external metadata as JsonNode.

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -35,6 +35,11 @@
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/model/src/main/java/uk/gov/pay/commons/api/validation/ExternalJsonMetadataValidator.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/validation/ExternalJsonMetadataValidator.java
@@ -1,0 +1,93 @@
+package uk.gov.pay.commons.api.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ExternalJsonMetadataValidator implements ConstraintValidator<ValidExternalJsonMetadata, JsonNode> {
+
+    private static final int MAXIMUM_KEYS = 10;
+    private static final int MAXIMUM_VALUE_LENGTH = 50;
+    private static final int MAXIMUM_KEY_LENGTH = 30;
+
+    @Override
+    public boolean isValid(JsonNode jsonNode, ConstraintValidatorContext constraintValidatorContext) {
+
+        if (jsonNode == null) {
+            return true;
+        }
+
+        constraintValidatorContext.disableDefaultConstraintViolation();
+
+        if (jsonNode.isArray()) {
+            addConstraint("must be an object of JSON key-value pairs", constraintValidatorContext);
+            return false;
+        }
+
+        var errorMessages = validateKeyValuePairs(jsonNode);
+
+        if (errorMessages.size() > 0) {
+            addConstraints(errorMessages, constraintValidatorContext);
+            return false;
+        }
+
+        return true;
+    }
+
+    private Set<String> validateKeyValuePairs(JsonNode keyPairs) {
+        Set<String> errorMessages = new HashSet<>();
+
+        if (keyPairs.size() > MAXIMUM_KEYS) {
+            errorMessages.add(String.format("cannot have more than %d key-value pairs", MAXIMUM_KEYS));
+        }
+
+        keyPairs.fields()
+                .forEachRemaining(
+                        (entry) -> errorMessages.addAll(validateKeyAndValue(entry.getKey(), entry.getValue()))
+                );
+
+        return errorMessages;
+    }
+
+    private Set<String> validateKeyAndValue(String key, JsonNode value) {
+        Set<String> errorMessages = new HashSet<>();
+
+        if (key == null) {
+            errorMessages.add("keys must not be null");
+        } else if (keyLengthIsInvalid(key)) {
+            errorMessages.add(String.format("keys must be between 1 and %d characters long", MAXIMUM_KEY_LENGTH));
+        }
+
+        if (valueTypeIsNotAllowed(value)) {
+            errorMessages.add(String.format("value for '%s' must be of type string, boolean or number", key));
+        }
+
+        if (valueIsTooLong(value)) {
+            errorMessages.add(String.format("value for '%s' must be a maximum of %d characters", key, MAXIMUM_VALUE_LENGTH));
+        }
+        return errorMessages;
+    }
+
+    private boolean keyLengthIsInvalid(String key) {
+        return key.length() < 1 || key.length() > MAXIMUM_KEY_LENGTH;
+    }
+
+    private boolean valueIsTooLong(JsonNode value) {
+        return value.asText().length() > MAXIMUM_VALUE_LENGTH;
+    }
+
+    private boolean valueTypeIsNotAllowed(JsonNode value) {
+        return !(value.isBoolean() || value.isNumber() || value.isTextual());
+    }
+
+    private void addConstraints(Set<String> errorMessages, ConstraintValidatorContext context) {
+        errorMessages.iterator().forEachRemaining(errorMessage -> addConstraint(errorMessage, context));
+    }
+
+    private void addConstraint(String errorMessage, ConstraintValidatorContext context) {
+        context.buildConstraintViolationWithTemplate(errorMessage).addConstraintViolation();
+    }
+}

--- a/model/src/main/java/uk/gov/pay/commons/api/validation/ValidExternalJsonMetadata.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/validation/ValidExternalJsonMetadata.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.commons.api.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ExternalJsonMetadataValidator.class)
+public @interface ValidExternalJsonMetadata {
+
+    String message() default "Invalid metadata";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/api/Validation/ValidExternalJsonMetadataTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/Validation/ValidExternalJsonMetadataTest.java
@@ -1,0 +1,175 @@
+package uk.gov.pay.commons.api.Validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import uk.gov.pay.commons.api.validation.ValidExternalJsonMetadata;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ValidExternalJsonMetadataTest {
+
+    private static Validator validator;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeClass
+    public static void setUp() {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    public void shouldPassValidation() {
+        ObjectNode validMetadata = objectMapper.createObjectNode();
+        validMetadata.put("key1", "value1");
+        validMetadata.put("key2", 123);
+        validMetadata.put("key3", true);
+        validMetadata.put("key4", "value4");
+        TestClass aTestClass = new TestClass(validMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(0));
+    }
+
+    @Test
+    public void shouldPassForNullValue() {
+        TestClass aTestClass = new TestClass(null);
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(0));
+    }
+
+    @Test
+    public void shouldFailValidationMultipleInvalidValueTypes() {
+        JsonNode nestedJsonObject = objectMapper.createObjectNode();
+        JsonNode nestedJsonArray = objectMapper.createArrayNode();
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        invalidMetadata.set("key1", nestedJsonObject);
+        invalidMetadata.set("key2", nestedJsonArray);
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<String> expectedErrors = Set.of(
+                "value for 'key1' must be of type string, boolean or number",
+                "value for 'key2' must be of type string, boolean or number");
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(2));
+        assertThat(expectedErrors.contains(violationSet.iterator().next().getMessage()), is(true));
+        assertThat(expectedErrors.contains(violationSet.iterator().next().getMessage()), is(true));
+    }
+
+    @Test
+    public void shouldFailValidationForTooManyKeys() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        int maximumKeysAllowed = 10;
+        for (int i = 0; i < maximumKeysAllowed + 5; i++) {
+            invalidMetadata.put("key" + i, "value" + i);
+        }
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(1));
+        assertThat(violationSet.iterator().next().getMessage(), is("cannot have more than " + maximumKeysAllowed + " key-value pairs"));
+    }
+
+    @Test
+    public void shouldFailValidationKeyTooLong() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        String tooLongKeyName = "this key is over thirty characters long and is invalid";
+        invalidMetadata.put(tooLongKeyName, "value1");
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(1));
+        assertThat(violationSet.iterator().next().getMessage(), is("keys must be between 1 and 30 characters long"));
+    }
+
+    @Test
+    public void shouldFailValidationEmptyKey() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        invalidMetadata.put("", "value1");
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(1));
+        assertThat(violationSet.iterator().next().getMessage(), is("keys must be between 1 and 30 characters long"));
+    }
+
+    @Test
+    public void shouldFailValidationValueTooLong() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        String tooLongValue = "this string is over fifty characters long by the time I've finished typing";
+        invalidMetadata.put("key1", tooLongValue);
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(1));
+        assertThat(violationSet.iterator().next().getMessage(), is("value for 'key1' must be a maximum of 50 characters"));
+    }
+
+    @Test
+    public void shouldFailValidationForArrayNode() {
+        JsonNode invalidMetadata = objectMapper.createArrayNode();
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(1));
+        assertThat(violationSet.iterator().next().getMessage(), is("must be an object of JSON key-value pairs"));
+    }
+
+    @Test
+    public void shouldFailValidationForNullKey() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        invalidMetadata.put(null, "someValue");
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(1));
+        assertThat(violationSet.iterator().next().getMessage(), is("keys must not be null"));
+    }
+
+    @Test
+    public void shouldFailValidationForNullKeyAndInvalidValue() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        invalidMetadata.set(null, objectMapper.createArrayNode());
+        Set<String> expectedErrorMessages = Set.of(
+                "keys must not be null",
+                "value for 'null' must be of type string, boolean or number");
+
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(2));
+        assertThat(expectedErrorMessages.contains(violationSet.iterator().next().getMessage()), is(true));
+        assertThat(expectedErrorMessages.contains(violationSet.iterator().next().getMessage()), is(true));
+    }
+
+    @Test
+    public void shouldFailValidationForNullValue() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        invalidMetadata.set("key1", (JsonNode) null);
+        TestClass aTestClass = new TestClass(invalidMetadata);
+
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(1));
+        assertThat(violationSet.iterator().next().getMessage(), is("value for 'key1' must be of type string, boolean or number"));
+    }
+
+    public static class TestClass {
+
+        @ValidExternalJsonMetadata()
+        private final JsonNode metadata;
+
+        TestClass(JsonNode metadata) {
+            this.metadata = metadata;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
         <jackson.version>2.9.8</jackson.version>
         <bintray.username/>
         <bintray.apiKey/>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <modules>
@@ -31,6 +33,24 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.0.16.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b09</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>java-hamcrest</artifactId>
+            <version>2.0.0.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>metrics-graphite</artifactId>
             <version>4.0.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.4.0.Final</version>
+        </dependency>
         <!-- Test dependencies go below here -->
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Add `ValidExternalJsonMetadata` annotation and associated validator.
Add unit tests for validation.