### PR TITLE
PP-4884: Use functional style validation

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -41,9 +41,9 @@
             <version>2.0.1.Final</version>
         </dependency>
         <dependency>
-            <groupId>org.functionaljava</groupId>
-            <artifactId>functionaljava</artifactId>
-            <version>4.8.1</version>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>27.1-jre</version>
         </dependency>
     </dependencies>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
         </dependency>
+        <dependency>
+            <groupId>org.functionaljava</groupId>
+            <artifactId>functionaljava</artifactId>
+            <version>4.8.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/model/src/test/java/uk/gov/pay/commons/api/Validation/ValidExternalJsonMetadataTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/Validation/ValidExternalJsonMetadataTest.java
@@ -58,13 +58,11 @@ public class ValidExternalJsonMetadataTest {
         String tooLongValue = "this string is over fifty characters long by the time I've finished typing";
         invalidMetadata.put("key1", tooLongValue);
 
-        invalidMetadata.put(null, "someValue");
-
         invalidMetadata.set("key2", null);
 
         TestClass aTestClass = new TestClass(invalidMetadata);
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
-        assertThat(violationSet.size(), is(5));
+        assertThat(violationSet.size(), is(4));
     }
 
     @Test
@@ -77,8 +75,8 @@ public class ValidExternalJsonMetadataTest {
         TestClass aTestClass = new TestClass(invalidMetadata);
 
         Set<String> expectedErrors = Set.of(
-                "value for 'key1' must be of type string, boolean or number",
-                "value for 'key2' must be of type string, boolean or number");
+                "metadata value for 'key1' must be of type string, boolean or number",
+                "metadata value for 'key2' must be of type string, boolean or number");
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(2));
@@ -97,7 +95,7 @@ public class ValidExternalJsonMetadataTest {
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(1));
-        assertThat(violationSet.iterator().next().getMessage(), is("cannot have more than " + maximumKeysAllowed + " key-value pairs"));
+        assertThat(violationSet.iterator().next().getMessage(), is("metadata cannot have more than " + maximumKeysAllowed + " key-value pairs"));
     }
 
     @Test
@@ -109,7 +107,7 @@ public class ValidExternalJsonMetadataTest {
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(1));
-        assertThat(violationSet.iterator().next().getMessage(), is("keys must be between 1 and 30 characters long"));
+        assertThat(violationSet.iterator().next().getMessage(), is("metadata keys must be between 1 and 30 characters long"));
     }
 
     @Test
@@ -120,7 +118,7 @@ public class ValidExternalJsonMetadataTest {
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(1));
-        assertThat(violationSet.iterator().next().getMessage(), is("keys must be between 1 and 30 characters long"));
+        assertThat(violationSet.iterator().next().getMessage(), is("metadata keys must be between 1 and 30 characters long"));
     }
 
     @Test
@@ -132,7 +130,7 @@ public class ValidExternalJsonMetadataTest {
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(1));
-        assertThat(violationSet.iterator().next().getMessage(), is("value for 'key1' must be a maximum of 50 characters"));
+        assertThat(violationSet.iterator().next().getMessage(), is("metadata value for 'key1' must be a maximum of 50 characters"));
     }
 
     @Test
@@ -142,34 +140,7 @@ public class ValidExternalJsonMetadataTest {
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(1));
-        assertThat(violationSet.iterator().next().getMessage(), is("must be an object of JSON key-value pairs"));
-    }
-
-    @Test
-    public void shouldFailValidationForNullKey() {
-        ObjectNode invalidMetadata = objectMapper.createObjectNode();
-        invalidMetadata.put(null, "someValue");
-        TestClass aTestClass = new TestClass(invalidMetadata);
-
-        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
-        assertThat(violationSet.size(), is(1));
-        assertThat(violationSet.iterator().next().getMessage(), is("keys must not be null"));
-    }
-
-    @Test
-    public void shouldFailValidationForNullKeyAndInvalidValue() {
-        ObjectNode invalidMetadata = objectMapper.createObjectNode();
-        invalidMetadata.set(null, objectMapper.createArrayNode());
-        Set<String> expectedErrorMessages = Set.of(
-                "keys must not be null",
-                "value for 'null' must be of type string, boolean or number");
-
-        TestClass aTestClass = new TestClass(invalidMetadata);
-
-        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
-        assertThat(violationSet.size(), is(2));
-        assertThat(expectedErrorMessages.contains(violationSet.iterator().next().getMessage()), is(true));
-        assertThat(expectedErrorMessages.contains(violationSet.iterator().next().getMessage()), is(true));
+        assertThat(violationSet.iterator().next().getMessage(), is("metadata must be an object of JSON key-value pairs"));
     }
 
     @Test
@@ -180,7 +151,7 @@ public class ValidExternalJsonMetadataTest {
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(1));
-        assertThat(violationSet.iterator().next().getMessage(), is("value for 'key1' must be of type string, boolean or number"));
+        assertThat(violationSet.iterator().next().getMessage(), is("metadata value for 'key1' must be of type string, boolean or number"));
     }
 
     public static class TestClass {

--- a/model/src/test/java/uk/gov/pay/commons/api/Validation/ValidExternalJsonMetadataTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/Validation/ValidExternalJsonMetadataTest.java
@@ -46,6 +46,26 @@ public class ValidExternalJsonMetadataTest {
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
         assertThat(violationSet.size(), is(0));
     }
+    
+    @Test
+    public void shouldCollateMultipleErrors() {
+        ObjectNode invalidMetadata = objectMapper.createObjectNode();
+        invalidMetadata.set("key", objectMapper.createObjectNode());
+        
+        String tooLongKeyName = "this key is over thirty characters long and is invalid";
+        invalidMetadata.put(tooLongKeyName, "value1");
+
+        String tooLongValue = "this string is over fifty characters long by the time I've finished typing";
+        invalidMetadata.put("key1", tooLongValue);
+
+        invalidMetadata.put(null, "someValue");
+
+        invalidMetadata.set("key2", null);
+
+        TestClass aTestClass = new TestClass(invalidMetadata);
+        Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);
+        assertThat(violationSet.size(), is(5));
+    }
 
     @Test
     public void shouldFailValidationMultipleInvalidValueTypes() {
@@ -155,7 +175,7 @@ public class ValidExternalJsonMetadataTest {
     @Test
     public void shouldFailValidationForNullValue() {
         ObjectNode invalidMetadata = objectMapper.createObjectNode();
-        invalidMetadata.set("key1", (JsonNode) null);
+        invalidMetadata.set("key1", null);
         TestClass aTestClass = new TestClass(invalidMetadata);
 
         Set<ConstraintViolation<TestClass>> violationSet = validator.validate(aTestClass);


### PR DESCRIPTION
Split each validation into its own function and perform the validation on the
metadata json by composing these functions. This also gives us the possibility
of reusing these functions somewhere else if needed. These functions basically
take a JsonNode, and a list of errors, and appends any errors to the list of
errors if there are any.

This style of coding might not be palatable to some, so I'm perfectly open for this PR to be voted down. I won't be offended!