### PR TITLE
PP-4886: Serialise empty metadata string to null object

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/api/json/ExternalMetadataDeserialiser.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/json/ExternalMetadataDeserialiser.java
@@ -20,7 +20,7 @@ public class ExternalMetadataDeserialiser extends JsonDeserializer<ExternalMetad
 
         Map<String, Object> metadata = jsonParser.getCodec().readValue(jsonParser, new TypeReference<Map<String, Object>>() {});
         if (metadata != null) {
-            return new ExternalMetadata(metadata);
+            return metadata.isEmpty() ? null : new ExternalMetadata(metadata);
         }
 
         assert false : "This should never be invoked since we currently do no deserialize null values.";

--- a/model/src/test/java/uk/gov/pay/commons/api/json/ExternalMetadataDeserialiserTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/ExternalMetadataDeserialiserTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.commons.api.json;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.junit.Before;
@@ -9,9 +8,9 @@ import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ExternalMetadataDeserialiserTest {
@@ -27,6 +26,12 @@ public class ExternalMetadataDeserialiserTest {
     }
     
     @Test
+    public void shouldReturnNullIfValueIsAnEmptyJson() throws Exception {
+        ExternalMetadata externalMetadata = objectMapper.readValue("{}", ExternalMetadata.class);
+        assertNull(externalMetadata);
+    }
+    
+    @Test
     public void shouldDeserialise() throws Exception {
         String metadata = "{\"ledger_code\":\"123\", \"fund_code\":\"1234\"}";
         ExternalMetadata externalMetadata = objectMapper.readValue(metadata, ExternalMetadata.class);
@@ -37,7 +42,7 @@ public class ExternalMetadataDeserialiserTest {
     }
 
     @Test
-    public void shouldReturnErrorIfValueIsNotAnObject() throws Exception {
+    public void shouldReturnErrorIfValueIsNotAnObject() {
         String metadata = "some text";
         try {
             objectMapper.convertValue(metadata, ExternalMetadata.class);


### PR DESCRIPTION
It's been agreed with @danworth and @alexbishop1 we should be lenient and
accept create payment requets where metadata is empty:

```
"metadata": {}
```

If this happens we want to treat the payment as if it had no metadata.
Therefore this needs to be serialized to null which means the payment will have
no jsonb metadata in the database which is what we want.