### PR TITLE
PP-4911: Deprecate mockserver

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -16,20 +16,9 @@
     <properties>
         <docker-client.version>8.15.3</docker-client.version>
         <pact.version>3.6.7</pact.version>
-        <mockserver.version>5.5.4</mockserver.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>${mockserver.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-client-java</artifactId>
-            <version>${mockserver.version}</version>
-        </dependency>
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>

--- a/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/PactProviderRule.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/pact/consumers/PactProviderRule.java
@@ -5,7 +5,6 @@ import au.com.dius.pact.model.FileSource;
 import au.com.dius.pact.model.RequestResponsePact;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.mockserver.socket.PortFactory;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -20,6 +19,7 @@ import static au.com.dius.pact.model.PactReader.loadPact;
 import static com.google.common.io.Resources.getResource;
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
+import static uk.gov.pay.commons.testing.port.PortFactory.findFreePort;
 
 public class PactProviderRule extends PactProviderRuleMk2 {
 
@@ -27,7 +27,7 @@ public class PactProviderRule extends PactProviderRuleMk2 {
     private List<String> pactsToDelete = new ArrayList<>();
     
     public PactProviderRule(String provider, Object target) {
-        super(provider, "localhost", PortFactory.findFreePort(), target);
+        super(provider, "localhost", findFreePort(), target);
     }
 
     @Override

--- a/testing/src/main/java/uk/gov/pay/commons/testing/port/PortFactory.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/port/PortFactory.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.commons.testing.port;
+
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+public class PortFactory {
+    public static int findFreePort() {
+        int port;
+        try {
+            ServerSocket server = new ServerSocket(0);
+            port = server.getLocalPort();
+            server.close();
+            // allow time for the socket to be released
+            TimeUnit.MILLISECONDS.sleep(350);
+        } catch (Exception e) {
+            throw new RuntimeException("Exception while trying to find a free port", e);
+        }
+        return port;
+    }
+}


### PR DESCRIPTION
- Remove dependency on mockserver
- Move PortFactory from pay-connector's project so it can be used by publicapi
  as well