### PR TITLE
PP-5219 add logic to LoggingFilter for json type logs

### DIFF
--- a/utils/src/main/java/uk/gov/pay/commons/utils/logging/LoggingFilter.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/logging/LoggingFilter.java
@@ -21,6 +21,8 @@ public class LoggingFilter implements Filter {
      * This key should match the value in our logging configuration e.g. %X{X-Request-Id:-(none)}
      */
     private static final String MDC_REQUEST_ID_KEY = "X-Request-Id";
+    
+    private static final String MDC_JSON_REQUEST_ID_KEY = "requestID";
 
     private final MetricRegistry metricRegistry;
 
@@ -46,8 +48,10 @@ public class LoggingFilter implements Filter {
 
         if (requestId == null) {
             MDC.remove(MDC_REQUEST_ID_KEY);
+            MDC.put(MDC_JSON_REQUEST_ID_KEY, "(none)");
         } else {
             MDC.put(MDC_REQUEST_ID_KEY, requestId);
+            MDC.put(MDC_JSON_REQUEST_ID_KEY, requestId);
         }
 
         logger.info("{} to {} began", requestMethod, requestURL);


### PR DESCRIPTION
- add logic to LoggingFilter for json type logs. 
Custom MDC fields can not be referenced from the json type layout in the logging configuration. To be backwards compatible we need to include two fields within the filter chain. Old school projects (which are using logFormat) will still access `X-Request-Id` while projects having the json type logging will use the new field `requestID`.