### PR TITLE
PP-5297: Optional matcher

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -16,9 +16,15 @@
     <properties>
         <docker-client.version>8.16.0</docker-client.version>
         <pact.version>3.6.7</pact.version>
+        <hamcrest.version>2.1</hamcrest.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
+        </dependency>
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>

--- a/testing/src/main/java/uk/gov/pay/commons/testing/matchers/HamcrestMatchers.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/matchers/HamcrestMatchers.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.commons.testing.matchers;
+
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+public class HamcrestMatchers {
+
+    public static Matcher<Object> optionalMatcher(String value) {
+        return value == null ? is(nullValue()) : is(value);
+    }
+}


### PR DESCRIPTION
Moving the following code (from https://github.com/alphagov/pay-direct-debit-connector/blob/master/src/test/java/uk/gov/pay/directdebit/mandate/resources/MandateResourceIT.java#L176-L178):

```
    private Matcher<Object> optionalDescriptionMatcher(String description) {
        return description == null ? is(nullValue()) : is(notNullValue());
    }
```

as it can be used in other projects.