### PR TITLE
PP-5318 Abstract type for value types that wrap strings

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/model/WrappedStringValue.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/WrappedStringValue.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.commons.model;
+
+import java.util.Objects;
+
+public abstract class WrappedStringValue {
+
+    private final String value;
+
+    public WrappedStringValue(String value) {
+        this.value = Objects.requireNonNull(value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (this == that) {
+            return true;
+        }
+
+        if (that != null && this.getClass() == that.getClass()) {
+            WrappedStringValue wrappedStringValueWithSameRuntimeTypeAsThisObject = (WrappedStringValue) that;
+            return this.value.equals(wrappedStringValueWithSameRuntimeTypeAsThisObject.value);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/model/WrappedStringValueTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/WrappedStringValueTest.java
@@ -1,0 +1,113 @@
+package uk.gov.pay.commons.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class WrappedStringValueTest {
+
+    @Test
+    @SuppressWarnings("SimplifiableJUnitAssertion")
+    public void twoObjectsWithSameRuntimeTypeAndSameStringValueAreEqual() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+        var b = ConcreteWrappedStringValue.valueOf("foo");
+
+        assertTrue(a.equals(b));
+        assertTrue(b.equals(a));
+    }
+
+    @Test
+    @SuppressWarnings("SimplifiableJUnitAssertion")
+    public void twoObjectsWithSameRuntimeTypeAndDifferentStringValuesAreNotEqual() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+        var b = ConcreteWrappedStringValue.valueOf("bar");
+
+        assertFalse(a.equals(b));
+        assertFalse(b.equals(a));
+    }
+
+    @Test
+    @SuppressWarnings({"EqualsBetweenInconvertibleTypes", "SimplifiableJUnitAssertion"})
+    public void twoObjectsWithDifferentRuntimeTypesAndSameStringValueAreNotEqual() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+        var b = DifferentConcreteWrappedStringValueType.valueOf("foo");
+
+        assertFalse(a.equals(b));
+        assertFalse(b.equals(a));
+    }
+
+    @Test
+    @SuppressWarnings({"EqualsBetweenInconvertibleTypes", "SimplifiableJUnitAssertion"})
+    public void twoObjectsWithDifferentRuntimeTypesAndDifferentStringValuesAreNotEqual() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+        var b = DifferentConcreteWrappedStringValueType.valueOf("bar");
+
+        assertFalse(a.equals(b));
+        assertFalse(b.equals(a));
+    }
+
+    @Test
+    @SuppressWarnings({"ConstantConditions", "EqualsBetweenInconvertibleTypes", "SimplifiableJUnitAssertion"})
+    public void notEqualToObjectOfCompletelyDifferentType() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+        var b = "foo";
+
+        assertFalse(a.equals(b));
+    }
+
+    @Test
+    @SuppressWarnings({"ConstantConditions", "SimplifiableJUnitAssertion"})
+    public void notEqualToNull() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+
+        assertFalse(a.equals(null));
+    }
+
+    @Test
+    public void twoEqualObjectsHaveSameHashCode() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+        var b = ConcreteWrappedStringValue.valueOf("foo");
+        
+        assertThat(a.hashCode(), is(b.hashCode()));
+    }
+
+    @Test
+    public void toStringReturnsWrappedStringValue() {
+        var a = ConcreteWrappedStringValue.valueOf("foo");
+
+        assertThat(a.toString(), is("foo"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cannotInstantiateWithNullString() {
+        ConcreteWrappedStringValue.valueOf(null);
+    }
+
+    private static class ConcreteWrappedStringValue extends WrappedStringValue {
+
+        private ConcreteWrappedStringValue(String value) {
+            super(value);
+        }
+
+        static ConcreteWrappedStringValue valueOf(String value) {
+            return new ConcreteWrappedStringValue(value);
+        }
+
+    }
+
+    private static class DifferentConcreteWrappedStringValueType extends WrappedStringValue {
+
+        private DifferentConcreteWrappedStringValueType(String value) {
+            super(value);
+        }
+
+        static DifferentConcreteWrappedStringValueType valueOf(String value) {
+            return new DifferentConcreteWrappedStringValueType(value);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Add an abstract class that wraps a string. This can make the implementation of our burgeoning collection of specific value types (types that represent particular IDs etc.) simpler because they don’t each need to implement `equals(…)` and the like (which can be surprisingly hard to get right sometimes!).

The wrapped string must not be null. To be considered equal, two objects must have both the same runtime type and the same string value: instances of different subtypes that wrap the same string are not equal.

Use it like this:

```java
public class ExternalPaymentId extends WrappedStringValue {

    private ExternalPaymentId(String id) {
        super(id);
    }

    public static ExternalPaymentId valueOf(String id) {
        return new ExternalPaymentId(id);
    }

}
```