### PR TITLE
PP-5542 Reference Node.js logging keys in Java logging keys

### DIFF
--- a/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
+++ b/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
@@ -1,5 +1,9 @@
 package uk.gov.pay.logging;
 
+/**
+ * This file needs to be kept in sync with its Node.js consociate
+ * @see <a href="https://github.com/alphagov/pay-js-commons/blob/master/src/logging-keys/index.js">https://github.com/alphagov/pay-js-commons/blob/master/src/logging-keys/index.js</a>
+ */
 public interface LoggingKeys {
 
     /**


### PR DESCRIPTION
Add some Javadoc to `LoggingKeys` noting that it must be kept in sync with the equivalent Node.js files.