### PR TITLE
PP-5735: Allow json logging of static data

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -24,6 +24,12 @@
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+
     </dependencies>
     <artifactId>logging</artifactId>
     <packaging>jar</packaging>

--- a/logging/src/main/java/uk/gov/pay/logging/LogstashConsoleAppenderFactory.java
+++ b/logging/src/main/java/uk/gov/pay/logging/LogstashConsoleAppenderFactory.java
@@ -7,14 +7,19 @@ import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.encoder.Encoder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.gson.Gson;
 import io.dropwizard.logging.ConsoleAppenderFactory;
 import io.dropwizard.logging.async.AsyncAppenderFactory;
 import io.dropwizard.logging.filter.LevelFilterFactory;
 import io.dropwizard.logging.layout.LayoutFactory;
 import net.logstash.logback.encoder.LogstashEncoder;
 
+import java.util.Map;
+
 @JsonTypeName("logstash-console")
 public class LogstashConsoleAppenderFactory extends ConsoleAppenderFactory<ILoggingEvent> {
+
+    private Map<String, String> customFields;
 
     @Override
     public Appender<ILoggingEvent> build(LoggerContext context,
@@ -23,7 +28,8 @@ public class LogstashConsoleAppenderFactory extends ConsoleAppenderFactory<ILogg
                                          LevelFilterFactory<ILoggingEvent> levelFilterFactory,
                                          AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory) {
 
-        Encoder<ILoggingEvent> encoder = new LogstashEncoder();
+        LogstashEncoder encoder = new LogstashEncoder();
+        encoder.setCustomFields(new Gson().toJson(customFields));
         encoder.setContext(context);
         encoder.start();
 
@@ -39,5 +45,13 @@ public class LogstashConsoleAppenderFactory extends ConsoleAppenderFactory<ILogg
         appender.start();
 
         return wrapAsync(appender, asyncAppenderFactory);
+    }
+
+    public Map<String, String> getCustomFields() {
+        return customFields;
+    }
+
+    public void setCustomFields(Map<String, String> customFields) {
+        this.customFields = customFields;
     }
 }


### PR DESCRIPTION
We want our java applications to log its service name in the json logs. We
don't want to have to do this by adding the name in the MDC; its easier to be
able to define it in the application's config yaml file. Unfortunately due to
our custom LogstashConsoleAppenderFactory - which nicely logs structured
arguments and various GDS standard keys (E.g. '@timestamp', '@version') - we don't
use the standard dropwizard json logging which would have allowed us to use the
`additionalFields` in the config yaml file (see
`io.dropwizard.logging.json.layout.EventJsonLayout`). This commit allows our
java apps to have this sort of config:

```
logging:
  level: ERROR
  appenders:
    - type: logstash-console
      threshold: ALL
      timeZone: UTC
      target: stdout
      customFields:
        label: "directdebit-connector"
      layout:
        type: json
```