### PR TITLE
PP-5735: Use GDS convention for json logging key names

### DIFF
--- a/utils/src/main/java/uk/gov/pay/commons/utils/logging/LoggingFilter.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/logging/LoggingFilter.java
@@ -20,7 +20,7 @@ public class LoggingFilter implements Filter {
     /**
      * This key should match the value in our logging configuration e.g. %X{X-Request-Id:-(none)}
      */
-    private static final String MDC_REQUEST_ID_KEY = "X-Request-Id";
+    private static final String MDC_REQUEST_ID_KEY = "x_request_id";
 
     private final MetricRegistry metricRegistry;
 

--- a/utils/src/test/java/uk/gov/pay/commons/utils/logging/LoggingFilterTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/logging/LoggingFilterTest.java
@@ -123,15 +123,15 @@ public class LoggingFilterTest {
 
         when(mockRequest.getHeader("X-Request-Id")).thenReturn("some-id");
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
-        assertThat(MDC.get("X-Request-Id"), is("some-id"));
+        assertThat(MDC.get("x_request_id"), is("some-id"));
 
         when(mockRequest.getHeader("X-Request-Id")).thenReturn("some-other-id");
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
-        assertThat(MDC.get("X-Request-Id"), is("some-other-id"));
+        assertThat(MDC.get("x_request_id"), is("some-other-id"));
 
         when(mockRequest.getHeader("X-Request-Id")).thenReturn(null);
         loggingFilter.doFilter(mockRequest, mockResponse, mockFilterChain);
-        assertThat(MDC.get("X-Request-Id"), is(nullValue()));
+        assertThat(MDC.get("x_request_id"), is(nullValue()));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
The http `X-Request-Id` header is put in an MDC which will become a key in an application's json log output.