### PR TITLE
PP-5776: Custom json logging factory

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -5,7 +5,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <dropwizard.version>1.3.15</dropwizard.version>
+        <dropwizard.version>1.3.16</dropwizard.version>
     </properties>
 
     <parent>
@@ -14,6 +14,11 @@
         <version>1.0.0</version>
     </parent>
     <dependencies>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
         <dependency>
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
@@ -29,7 +34,6 @@
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
         </dependency>
-
     </dependencies>
     <artifactId>logging</artifactId>
     <packaging>jar</packaging>

--- a/logging/src/main/java/uk/gov/pay/logging/GovUkPayAccessJsonLayoutFactory.java
+++ b/logging/src/main/java/uk/gov/pay/logging/GovUkPayAccessJsonLayoutFactory.java
@@ -1,0 +1,69 @@
+package uk.gov.pay.logging;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.LayoutBase;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.json.AccessJsonLayoutBaseFactory;
+import io.dropwizard.logging.json.layout.AccessJsonLayout;
+import io.dropwizard.logging.json.layout.TimestampFormatter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+/**
+ * This programmatically configures the JSON logging to be equivalent to:
+ *
+ *       - type: console
+ *         layout:
+ *           type: access-json
+ *           timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+ *           CUSTOM_FIELD_NAMES:
+ *             timestamp: "@timestamp"
+ *             userAgent: "user_agent"
+ *             requestTime: "response_time"
+ *             uri: "url"
+ *             protocol: "http_version"
+ *             status: "status_code"
+ *             contentLength: "content_length"
+ *             remoteAddress: "remote_address"
+ *           additionalFields:
+ *             "@version": 1
+ *             
+ * More additional fields can be added as required.
+ */
+@JsonTypeName("govuk-pay-access-json")
+public class GovUkPayAccessJsonLayoutFactory extends AccessJsonLayoutBaseFactory {
+
+    private static final Map<String, String> CUSTOM_FIELD_NAMES = Map.of(
+            "timestamp", "@timestamp",
+            "userAgent", "user_agent",
+            "requestTime", "response_time",
+            "uri", "url",
+            "protocol", "http_version",
+            "status", "status_code",
+            "contentLength", "content_length",
+            "remoteAddress", "remote_address"
+    );
+
+    private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+    @Override
+    public LayoutBase<IAccessEvent> build(LoggerContext context, TimeZone timeZone) {
+        var additionalFields = new HashMap<>(this.getAdditionalFields());
+        additionalFields.put("@version", 1);
+        var jsonLayout = new AccessJsonLayout(this.createDropwizardJsonFormatter(), createTimestampFormatter(timeZone),
+                getIncludes(), CUSTOM_FIELD_NAMES, additionalFields);
+        jsonLayout.setContext(context);
+        jsonLayout.setRequestHeaders(getRequestHeaders());
+        jsonLayout.setResponseHeaders(getResponseHeaders());
+        return jsonLayout;
+    }
+
+    @Override
+    protected TimestampFormatter createTimestampFormatter(TimeZone timeZone) {
+        return new TimestampFormatter(TIMESTAMP_FORMAT, timeZone.toZoneId());
+    }
+}
+

--- a/logging/src/main/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactory.java
+++ b/logging/src/main/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactory.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 /**
- * This programmatically configures the JSON logging to be equivalent to:
+ * This programmatically configures the dropwizard request log json logging to be equivalent to:
  *
  *       - type: console
  *         layout:
@@ -31,10 +31,11 @@ import java.util.TimeZone;
  *           additionalFields:
  *             "@version": 1
  *             
- * More additional fields can be added as required.
+ * More additional fields can be added as required; however it is mandatory to add a "container" key as this is 
+ * standard across all our dropwizard apps.
  */
 @JsonTypeName("govuk-pay-access-json")
-public class GovUkPayAccessJsonLayoutFactory extends AccessJsonLayoutBaseFactory {
+public class GovUkPayDropwizardRequestJsonLogLayoutFactory extends AccessJsonLayoutBaseFactory {
 
     private static final Map<String, String> CUSTOM_FIELD_NAMES = Map.of(
             "timestamp", "@timestamp",
@@ -51,6 +52,10 @@ public class GovUkPayAccessJsonLayoutFactory extends AccessJsonLayoutBaseFactory
 
     @Override
     public LayoutBase<IAccessEvent> build(LoggerContext context, TimeZone timeZone) {
+        if (!this.getAdditionalFields().containsKey("container")) {
+            throw new RuntimeException("When using govuk-pay-access-json, an additional field with the key of " +
+                    "\"container\" must be present");
+        }
         var additionalFields = new HashMap<>(this.getAdditionalFields());
         additionalFields.put("@version", 1);
         var jsonLayout = new AccessJsonLayout(this.createDropwizardJsonFormatter(), createTimestampFormatter(timeZone),

--- a/logging/src/test/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactoryTest.java
+++ b/logging/src/test/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactoryTest.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.logging;
+
+import org.junit.Test;
+
+import java.util.TimeZone;
+
+public class GovUkPayDropwizardRequestJsonLogLayoutFactoryTest {
+    
+    @Test(expected = RuntimeException.class)
+    public void throw_runtime_exception_if_no_additional_field_named_container() {
+        var jsonLogLayoutFactory = new GovUkPayDropwizardRequestJsonLogLayoutFactory();
+        jsonLogLayoutFactory.build(null, TimeZone.getDefault());
+    }
+}


### PR DESCRIPTION
Common class that configures dropwizard request logs, so projects can configure

```
server:
  requestLog:
    appenders:
      - type: console
        layout:
          type: govuk-pay-access-json
          additionalFields:
            container: "connector" #for example
```

instead of the current

```
server:
  requestLog:
    appenders:
      - type: console
        layout:
          type: access-json
          timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
          customFieldNames:
            timestamp: "@timestamp"
            userAgent: "user_agent"
            requestTime: "response_time"
            uri: "url"
            protocol: "http_version"
            status: "status_code"
            contentLength: "content_length"
            remoteAddress: "remote_address"
          additionalFields:
            container: "connector"
            "@version": 1
```