### PR TITLE
PP-5893: Specify the type of external id

### DIFF
--- a/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
+++ b/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
@@ -48,9 +48,9 @@ public interface LoggingKeys {
     String AMOUNT = "amount";
  
     /**
-     * The ID GOV.UK Pay gives to a payment, mandate, refund etc.
+     * Mandate external id
      */
-    String EXTERNAL_ID = "external_id";
+    String MANDATE_EXTERNAL_ID = "external_id";
 
     /**
      * The ID a provider gives to a payment, mandate, refund etc.


### PR DESCRIPTION
There are now `PAYMENT_EXTERNAL_ID` and `REFUND_EXTERNAL_ID` keys in
LoggingKeys. This is pertinent to a request like
`/v1/api/accounts/{accountId}/charges/{chargeId}/refunds/{refundId}` in
connector which will log the external charge id and external refund id in the
same json log. The current EXTERNAL_ID is only used once in
pay-direct-debit-connector to log the mandate id and so it's better named as
MANDATE_EXTERNAL_ID.