### PR TITLE
BAU — Tweak WrappedStringValue and its test

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/model/WrappedStringValue.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/WrappedStringValue.java
@@ -22,7 +22,7 @@ public abstract class WrappedStringValue {
         }
 
         if (that != null && this.getClass() == that.getClass()) {
-            WrappedStringValue wrappedStringValueWithSameRuntimeTypeAsThisObject = (WrappedStringValue) that;
+            var wrappedStringValueWithSameRuntimeTypeAsThisObject = (WrappedStringValue) that;
             return this.value.equals(wrappedStringValueWithSameRuntimeTypeAsThisObject.value);
         }
 

--- a/model/src/test/java/uk/gov/pay/commons/model/WrappedStringValueTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/WrappedStringValueTest.java
@@ -2,9 +2,9 @@ package uk.gov.pay.commons.model;
 
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class WrappedStringValueTest {
@@ -50,7 +50,7 @@ public class WrappedStringValueTest {
     }
 
     @Test
-    @SuppressWarnings({"ConstantConditions", "EqualsBetweenInconvertibleTypes", "SimplifiableJUnitAssertion"})
+    @SuppressWarnings({"EqualsBetweenInconvertibleTypes", "SimplifiableJUnitAssertion"})
     public void notEqualToObjectOfCompletelyDifferentType() {
         var a = ConcreteWrappedStringValue.valueOf("foo");
         var b = "foo";


### PR DESCRIPTION
- Use `var` rather than explicit type in one place
- Use Hamcrest `assertThat` rather than JUnit’s deprecated `assertThat`
- Remove an unnecessary `@SuppressWarnings` element