### PR TITLE
PP-6708 Upgrade to Junit5

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -52,12 +52,6 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <artifactId>logging</artifactId>
     <packaging>jar</packaging>

--- a/logging/src/test/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactoryTest.java
+++ b/logging/src/test/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactoryTest.java
@@ -1,14 +1,16 @@
 package uk.gov.pay.logging;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.TimeZone;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class GovUkPayDropwizardRequestJsonLogLayoutFactoryTest {
     
-    @Test(expected = RuntimeException.class)
+    @Test
     public void throw_runtime_exception_if_no_additional_field_named_container() {
         var jsonLogLayoutFactory = new GovUkPayDropwizardRequestJsonLogLayoutFactory();
-        jsonLogLayoutFactory.build(null, TimeZone.getDefault());
+        assertThrows(RuntimeException.class, () -> jsonLogLayoutFactory.build(null, TimeZone.getDefault()));
     }
 }

--- a/logging/src/test/java/uk/gov/pay/logging/LoggingFilterTest.java
+++ b/logging/src/test/java/uk/gov/pay/logging/LoggingFilterTest.java
@@ -6,13 +6,13 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import org.jboss.logging.MDC;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.FilterChain;
@@ -22,18 +22,17 @@ import java.io.IOException;
 import java.util.List;
 
 import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.matchesRegex;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LoggingFilterTest {
 
     private LoggingFilter loggingFilter;
@@ -52,7 +51,7 @@ public class LoggingFilterTest {
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setup() {
         loggingFilter = new LoggingFilter();
         Logger root = (Logger) LoggerFactory.getLogger(LoggingFilter.class);

--- a/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeDeserializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeDeserializerTest.java
@@ -5,19 +5,20 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
 
-import static junit.framework.TestCase.assertNull;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ApiResponseDateTimeDeserializerTest {
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() {
         objectMapper = new ObjectMapper();
         SimpleModule simpleModule = new SimpleModule();
@@ -42,11 +43,10 @@ public class ApiResponseDateTimeDeserializerTest {
         assertNull(response.getCreatedDate());
     }
 
-    @Test(expected = JsonMappingException.class)
-    public void shouldThrowExceptionWhenNullValue() throws IOException {
+    @Test
+    public void shouldThrowExceptionWhenNullValue() {
         String testValue = "{\"created_date\":\"blah\"}";
-        final RequestDateTimeJsonTest response = objectMapper.readValue(testValue, RequestDateTimeJsonTest.class);
-        assertNull(response.getCreatedDate());
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(testValue, RequestDateTimeJsonTest.class));
     }
 }
 

--- a/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeSerializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseDateTimeSerializerTest.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.time.ZonedDateTime;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ApiResponseDateTimeSerializerTest {
     private final ApiResponseDateTimeSerializer serializer = new ApiResponseDateTimeSerializer();

--- a/model/src/test/java/uk/gov/pay/commons/api/json/ExternalMetadataDeserialiserTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/ExternalMetadataDeserialiserTest.java
@@ -2,22 +2,22 @@ package uk.gov.pay.commons.api.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ExternalMetadataDeserialiserTest {
 
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() {
         objectMapper = new ObjectMapper();
         SimpleModule simpleModule = new SimpleModule();

--- a/model/src/test/java/uk/gov/pay/commons/api/json/MicrosecondPrecisionDateTimeDeserializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/MicrosecondPrecisionDateTimeDeserializerTest.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
@@ -14,11 +14,12 @@ import java.time.ZonedDateTime;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MicrosecondPrecisionDateTimeDeserializerTest {
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void before() {
         objectMapper = new ObjectMapper();
         SimpleModule simpleModule = new SimpleModule();
@@ -43,11 +44,10 @@ public class MicrosecondPrecisionDateTimeDeserializerTest {
         assertThat(deserialized.getCreatedDate(), is(nullValue()));
     }
 
-    @Test(expected = JsonMappingException.class)
-    public void shouldThrowExceptionWhenNullValue() throws IOException {
+    @Test
+    public void shouldThrowExceptionWhenNullValue() {
         String testValue = "{\"created_date\":\"blah\"}";
-        final TestMicrosecondDeserializerObject deserialized = objectMapper.readValue(testValue, TestMicrosecondDeserializerObject.class);
-        assertThat(deserialized.getCreatedDate(), is(nullValue()));
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(testValue, TestMicrosecondDeserializerObject.class));
     }
 }
 

--- a/model/src/test/java/uk/gov/pay/commons/api/json/MicrosecondPrecisionDateTimeSerializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/MicrosecondPrecisionDateTimeSerializerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;

--- a/model/src/test/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatterTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatterTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.commons.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/model/src/test/java/uk/gov/pay/commons/model/SupportedLanguageJsonDeserializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/SupportedLanguageJsonDeserializerTest.java
@@ -4,22 +4,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SupportedLanguageJsonDeserializerTest {
 
     private ObjectMapper mapper;
 
-    @Before
+    @BeforeEach
     public void setup() {
         mapper = new ObjectMapper();
     }

--- a/model/src/test/java/uk/gov/pay/commons/model/SupportedLanguageTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/SupportedLanguageTest.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.commons.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SupportedLanguageTest {
 
@@ -19,19 +20,19 @@ public class SupportedLanguageTest {
         assertThat(result, is(SupportedLanguage.WELSH));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void frThrowsException() {
-        SupportedLanguage.fromIso639AlphaTwoCode("fr");
+        assertThrows(IllegalArgumentException.class, () -> SupportedLanguage.fromIso639AlphaTwoCode("fr"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void enUpperCaseThrowsException() {
-        SupportedLanguage.fromIso639AlphaTwoCode("EN");
+        assertThrows(IllegalArgumentException.class, () -> SupportedLanguage.fromIso639AlphaTwoCode("EN"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void englishUpperCaseThrowsException() {
-        SupportedLanguage.fromIso639AlphaTwoCode("ENGLISH");
+        assertThrows(IllegalArgumentException.class, () -> SupportedLanguage.fromIso639AlphaTwoCode("ENGLISH"));
     }
 
 }

--- a/model/src/test/java/uk/gov/pay/commons/model/TokenPaymentTypeTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/TokenPaymentTypeTest.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.commons.model;
 
-import org.junit.Test;
 
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class TokenPaymentTypeTest {
 

--- a/model/src/test/java/uk/gov/pay/commons/model/WrappedStringValueTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/WrappedStringValueTest.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.commons.model;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WrappedStringValueTest {
 
@@ -70,7 +71,7 @@ public class WrappedStringValueTest {
     public void twoEqualObjectsHaveSameHashCode() {
         var a = ConcreteWrappedStringValue.valueOf("foo");
         var b = ConcreteWrappedStringValue.valueOf("foo");
-        
+
         assertThat(a.hashCode(), is(b.hashCode()));
     }
 
@@ -81,9 +82,9 @@ public class WrappedStringValueTest {
         assertThat(a.toString(), is("foo"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void cannotInstantiateWithNullString() {
-        ConcreteWrappedStringValue.valueOf(null);
+        assertThrows(NullPointerException.class, () -> ConcreteWrappedStringValue.valueOf(null));
     }
 
     private static class ConcreteWrappedStringValue extends WrappedStringValue {

--- a/model/src/test/java/uk/gov/pay/commons/model/charge/ExternalMetadataTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/charge/ExternalMetadataTest.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.commons.model.charge;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13</junit.version>
+        <junit5.version>5.6.2</junit5.version>
         <assertj.version>1.7.25</assertj.version>
         <jackson.version>2.11.0</jackson.version>
         <bintray.username/>
@@ -52,6 +53,30 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
             <version>2.0.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.6.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -128,6 +153,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
             </plugin>
         </plugins>
     </build>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -74,12 +74,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.12.2</version>

--- a/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresContainer.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresContainer.java
@@ -6,7 +6,11 @@ import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.LogStream;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.exceptions.DockerException;
-import com.spotify.docker.client.messages.*;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.LogConfig;
+import com.spotify.docker.client.messages.PortBinding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresDockerRule.java
+++ b/testing/src/main/java/uk/gov/pay/commons/testing/db/PostgresDockerRule.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.commons.testing.db;
 
-import com.spotify.docker.client.DefaultDockerClient;
-import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.exceptions.DockerException;
 import org.junit.rules.TestRule;

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -90,12 +90,6 @@
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/utils/src/test/java/uk/gov/pay/commons/utils/metrics/DatabaseMetricsServiceTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/metrics/DatabaseMetricsServiceTest.java
@@ -3,10 +3,10 @@ package uk.gov.pay.commons.utils.metrics;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -18,7 +18,7 @@ import static java.util.Map.entry;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DatabaseMetricsServiceTest {
     @Mock
     Connection mockConnection;

--- a/utils/src/test/java/uk/gov/pay/commons/utils/startup/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/startup/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -3,13 +3,13 @@ package uk.gov.pay.commons.utils.startup;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     private ApplicationStartupDependentResourceChecker applicationStartupDependentResourceChecker;
 
@@ -37,7 +37,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
-    @Before
+    @BeforeEach
     public void setup() {
         mockAppender = mock(Appender.class);
         ((Logger) LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class)).addAppender(mockAppender);

--- a/utils/src/test/java/uk/gov/pay/commons/utils/xray/XRaySessionProfilerTest.java
+++ b/utils/src/test/java/uk/gov/pay/commons/utils/xray/XRaySessionProfilerTest.java
@@ -9,8 +9,8 @@ import org.eclipse.persistence.queries.DatabaseQuery;
 import org.eclipse.persistence.sessions.DatabaseLogin;
 import org.eclipse.persistence.sessions.Record;
 import org.eclipse.persistence.sessions.SessionProfiler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
@@ -41,7 +41,7 @@ public class XRaySessionProfilerTest {
     private DatabaseLogin loginDetails = new DatabaseLogin();
     private SessionProfiler xrayProfiler;
 
-    @Before
+    @BeforeEach
     public void before() {
         MockitoAnnotations.initMocks(this);
         xrayProfiler = new XRaySessionProfiler(mockedRecorder);

--- a/validation/src/test/java/uk/gov/pay/commons/validation/DateTimeUtilsTest.java
+++ b/validation/src/test/java/uk/gov/pay/commons/validation/DateTimeUtilsTest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.commons.validation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -10,10 +10,10 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringEndsWith.endsWith;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DateTimeUtilsTest {
 


### PR DESCRIPTION
## WHAT
- Upgrades all modules (except testing) to Junit5.
- Most of tests (expect pact provider & consumer tests) now use Junit5 api for tests and assertions. Pact tests uses @\Rule annotations which will need to be replaced by extensions and to be looked into separately.
- Uses surefire plugin to run tests (both vintage - junit4 tests & jupiter - junit5 tests). Without the plugin, it is possible that tests won't run if Maven version is not the latest on target platform.