### PR TITLE
PP-7067 Increase maximum metadata value length from 50 to 100

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,83 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-09-11T11:32:05Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "testing/src/test/resources/pact-from-broker.json": [
+      {
+        "hashed_secret": "d046d31e2e14cb07ac95b087e349f28fa8ed752f",
+        "is_verified": false,
+        "line_number": 79,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "testing/src/test/resources/pact-publishing-test/pact-from-broker-2.json": [
+      {
+        "hashed_secret": "d046d31e2e14cb07ac95b087e349f28fa8ed752f",
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Hex High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/model/src/main/java/uk/gov/pay/commons/api/validation/ValidExternalMetadata.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/validation/ValidExternalMetadata.java
@@ -10,15 +10,19 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MAX_KEY_LENGTH;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MAX_KEY_VALUE_PAIRS;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MAX_VALUE_LENGTH;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MIN_KEY_LENGTH;
 
 @Target({FIELD, PARAMETER})
 @Retention(RUNTIME)
 @Constraint(validatedBy = {})
 @NotNull(message = "Field [metadata] must not be null")
-@Size(max = 10, message = "Field [metadata] cannot have more than {max} key-value pairs")
-@MapKeyLength(max = 30, min = 1, message = "Field [metadata] keys must be between {min} and {max} characters long")
+@Size(max = MAX_KEY_VALUE_PAIRS, message = "Field [metadata] cannot have more than {max} key-value pairs")
+@MapKeyLength(max = MAX_KEY_LENGTH, min = MIN_KEY_LENGTH, message = "Field [metadata] keys must be between {min} and {max} characters long")
 @MapValueTypes(types = {String.class, Number.class, Boolean.class}, message = "Field [metadata] values must be of type String, Boolean or Number")
-@MapValueLength(max = 50, message = "Field [metadata] values must be no greater than {max} characters long")
+@MapValueLength(max = MAX_VALUE_LENGTH, message = "Field [metadata] values must be no greater than {max} characters long")
 @MapValueNotNull(message = "Field [metadata] must not have null values")
 @MapKeyInsensitiveUnique(message = "Field [metadata] must have case insensitive unique keys")
 public @interface ValidExternalMetadata {

--- a/model/src/main/java/uk/gov/pay/commons/model/charge/ExternalMetadata.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/charge/ExternalMetadata.java
@@ -8,6 +8,11 @@ import java.util.Map;
 
 public class ExternalMetadata {
 
+    public static final int MAX_KEY_VALUE_PAIRS = 10;
+    public static final int MIN_KEY_LENGTH = 1;
+    public static final int MAX_KEY_LENGTH = 30;
+    public static final int MAX_VALUE_LENGTH = 100;
+
     @ValidExternalMetadata
     private final Map<String, Object> metadata;
 

--- a/model/src/test/java/uk/gov/pay/commons/model/charge/ExternalMetadataTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/charge/ExternalMetadataTest.java
@@ -12,16 +12,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static java.util.stream.Collectors.joining;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MAX_KEY_LENGTH;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MAX_KEY_VALUE_PAIRS;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MAX_VALUE_LENGTH;
+import static uk.gov.pay.commons.model.charge.ExternalMetadata.MIN_KEY_LENGTH;
 
 public class ExternalMetadataTest {
 
     private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
     private final ObjectMapper mapper = new ObjectMapper();
 
-    private final String TOO_LONG_VALUE = "This value is over fifty characters long and is invalid!";
-    private final String TOO_LONG_KEY = "This key is over thirty characters long and is invalid!";
+    private final String TOO_LONG_VALUE = IntStream.rangeClosed(1, MAX_VALUE_LENGTH + 1).mapToObj(i -> "a").collect(joining());
+    private final String TOO_LONG_KEY = IntStream.rangeClosed(1, MAX_KEY_LENGTH + 1).mapToObj(i -> "a").collect(joining());
 
     @Test
     public void shouldPassValidation() {
@@ -48,7 +53,7 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] cannot have more than 10 key-value pairs"));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] cannot have more than " + MAX_KEY_VALUE_PAIRS + " key-value pairs"));
     }
 
     @Test
@@ -59,7 +64,8 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] keys must be between 1 and 30 characters long"));
+        assertThat(violations.iterator().next().getMessage(),
+                is("Field [metadata] keys must be between " + MIN_KEY_LENGTH + " and " + MAX_KEY_LENGTH + " characters long"));
     }
 
     @Test
@@ -70,7 +76,8 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] keys must be between 1 and 30 characters long"));
+        assertThat(violations.iterator().next().getMessage(),
+                is("Field [metadata] keys must be between " + MIN_KEY_LENGTH + " and " + MAX_KEY_LENGTH + " characters long"));
     }
 
     @Test
@@ -81,7 +88,8 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] values must be no greater than 50 characters long"));
+        assertThat(violations.iterator().next().getMessage(),
+                is("Field [metadata] values must be no greater than " + MAX_VALUE_LENGTH + " characters long"));
     }
 
     @Test
@@ -128,8 +136,8 @@ public class ExternalMetadataTest {
         ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
         Set<String> expectedErrorMessages = Set.of(
                 "Field [metadata] values must be of type String, Boolean or Number",
-                "Field [metadata] values must be no greater than 50 characters long",
-                "Field [metadata] keys must be between 1 and 30 characters long");
+                "Field [metadata] values must be no greater than " + MAX_VALUE_LENGTH + " characters long",
+                "Field [metadata] keys must be between " + MIN_KEY_LENGTH + " and " + MAX_KEY_LENGTH + " characters long");
 
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
@@ -140,7 +148,7 @@ public class ExternalMetadataTest {
     }
 
     @Test
-    public void shouldFailWithDuplicateCaseInsensitiveKEysViolations() {
+    public void shouldFailWithDuplicateCaseInsensitiveKeysViolations() {
         Map<String, Object> metadata = Map.of(
                 "key", "string",
                 "Key", 1L


### PR DESCRIPTION
Increase the maximum number of characters allowed for a metadata value associated with a payment from 50 characters to 100.

Introduce some constants to make it easier to reuse maximum and minimum sizes relating to metadata elsewhere.