### PR TITLE
PP-7211 add non zoned date only string validator

### DIFF
--- a/validation/src/main/java/uk/gov/pay/commons/validation/DateTimeUtils.java
+++ b/validation/src/main/java/uk/gov/pay/commons/validation/DateTimeUtils.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.commons.validation;
 
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -49,5 +50,14 @@ public class DateTimeUtils {
      */
     public static String toLocalDateString(ZonedDateTime zonedDateTime) {
         return zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toLocalDate().format(localDateFormatter);
+    }
+
+    public static Optional<ZonedDateTime> fromLocalDateOnlyString(String localDateString) {
+        try {
+            ZonedDateTime utcTime = LocalDate.parse(localDateString).atStartOfDay(ZoneOffset.UTC);
+            return Optional.of(utcTime);
+        } catch (DateTimeParseException ex) {
+            return Optional.empty();
+        }
     }
 }

--- a/validation/src/test/java/uk/gov/pay/commons/validation/DateTimeUtilsTest.java
+++ b/validation/src/test/java/uk/gov/pay/commons/validation/DateTimeUtilsTest.java
@@ -72,4 +72,19 @@ public class DateTimeUtilsTest {
         assertTrue(result.isPresent());
         assertThat(result.get().toString(), endsWith("Z"));
     }
+
+    @Test
+    public void shouldCovertNonZonedDateStringZonedISO_8601StringToADateTime() {
+        String date = "2020-09-25";
+        Optional<ZonedDateTime> result = DateTimeUtils.fromLocalDateOnlyString(date);
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().toString(), is("2020-09-25T00:00Z"));
+    }
+
+    @Test
+    public void shouldNotCovertNonZonedDateStringToADateTimeIfNotISO_8601() {
+        String date = "2020/09/25";
+        Optional<ZonedDateTime> result = DateTimeUtils.fromLocalDateOnlyString(date);
+        assertThat(result.isPresent(), is(false));
+    }
 }


### PR DESCRIPTION
## WHAT
- add a validation option for non-zoned string representation of a date, like 2020-09-19
- add relevant test