### PR TITLE
PP-7242 Introduce a CardExpiryDate type for, er, card expiry dates

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/jpa/CardExpiryDateConverter.java
+++ b/model/src/main/java/uk/gov/pay/commons/jpa/CardExpiryDateConverter.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.commons.jpa;
+
+import uk.gov.pay.commons.model.CardExpiryDate;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class CardExpiryDateConverter implements AttributeConverter<CardExpiryDate, String> {
+
+    @Override
+    public String convertToDatabaseColumn(CardExpiryDate cardExpiryDate) {
+        if (cardExpiryDate == null) {
+            return null;
+        }
+
+        return cardExpiryDate.toString();
+    }
+
+    @Override
+    public CardExpiryDate convertToEntityAttribute(String cardExpiryDate) {
+        if (cardExpiryDate == null) {
+            return null;
+        }
+
+        return CardExpiryDate.valueOf(cardExpiryDate);
+    }
+
+}

--- a/model/src/main/java/uk/gov/pay/commons/model/CardExpiryDate.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/CardExpiryDate.java
@@ -1,0 +1,86 @@
+package uk.gov.pay.commons.model;
+
+import java.time.YearMonth;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public class CardExpiryDate {
+
+    public static final Pattern CARD_EXPIRY_DATE_PATTERN = Pattern.compile("(0[1-9]|1[0-2])/([(0-9]{2})");
+
+    private static final String PREFIX_TO_MAKE_2_DIGIT_YEAR_INTO_4_DIGIT_YEAR = "20";
+
+    private final String month2Digits;
+    private final String year2Digits;
+
+    private CardExpiryDate(String expiryDate) {
+        Objects.requireNonNull(expiryDate, "expiryDate");
+
+        var matcher = CARD_EXPIRY_DATE_PATTERN.matcher(expiryDate);
+
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Not in MM/yy format: " + expiryDate);
+        }
+
+        this.month2Digits = matcher.group(1);
+        this.year2Digits = matcher.group(2);
+    }
+
+    /**
+     * Parses a string in the MM/yy format used for expiry dates on most
+     * payment cards into a CardExpiryDate. For example, "09/22".
+     *
+     * Both the month and the year must be 2 digits, zero-padded if necessary
+     * (so "09" rather than "9"), thus the string must be exactly 5 characters
+     * in total.
+     **/
+    public static CardExpiryDate valueOf(String expiryDate) {
+        return new CardExpiryDate(expiryDate);
+    }
+
+    public String get2DigitMonth() {
+        return month2Digits;
+    }
+
+    public String get2DigitYear() {
+        return year2Digits;
+    }
+
+    public String get4DigitYear() {
+        return PREFIX_TO_MAKE_2_DIGIT_YEAR_INTO_4_DIGIT_YEAR + year2Digits;
+    }
+
+    public YearMonth toYearMonth() {
+        var month = Integer.parseInt(month2Digits);
+        var year = Integer.parseInt(get4DigitYear());
+        return YearMonth.of(year, month);
+    }
+
+    /**
+     * Returns the card expiry date in the MM/yy format used for expiry dates
+     * on most payment cards. For example, "09/22".
+     */
+    public String toString() {
+        return month2Digits + '/' + year2Digits;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (other == null || other.getClass() != CardExpiryDate.class) {
+            return false;
+        }
+
+        var that = (CardExpiryDate) other;
+        return this.month2Digits.equals(that.month2Digits) && this.year2Digits.equals(that.year2Digits);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(month2Digits, year2Digits);
+    }
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/jpa/CardExpiryDateConverterTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/jpa/CardExpiryDateConverterTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.commons.jpa;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.commons.model.CardExpiryDate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class CardExpiryDateConverterTest {
+
+    private final CardExpiryDateConverter cardExpiryDateConverter = new CardExpiryDateConverter();
+
+    @Test
+    void convertsCardExpiryDateToString() {
+        var cardExpiryDate = CardExpiryDate.valueOf("09/22");
+        String result = cardExpiryDateConverter.convertToDatabaseColumn(cardExpiryDate);
+        assertThat(result, is("09/22"));
+    }
+
+    @Test
+    void convertsNullCardExpiryDateToNull() {
+        String result = cardExpiryDateConverter.convertToDatabaseColumn(null);
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    void convertsStringToCardExpiryDate() {
+        CardExpiryDate result = cardExpiryDateConverter.convertToEntityAttribute("09/22");
+        assertThat(result, is(CardExpiryDate.valueOf("09/22")));
+    }
+
+    @Test
+    void convertsNullStringToNull() {
+        CardExpiryDate result = cardExpiryDateConverter.convertToEntityAttribute(null);
+        assertThat(result, is(nullValue()));
+    }
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/model/CardExpiryDateTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/CardExpiryDateTest.java
@@ -1,0 +1,365 @@
+package uk.gov.pay.commons.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.YearMonth;
+
+import static java.time.Month.APRIL;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JULY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MARCH;
+import static java.time.Month.MAY;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CardExpiryDateTest {
+
+    @Test
+    void month01Parses() {
+        var input = "01/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("01"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, JANUARY)));
+        assertThat(cardExpiryDate.toString(), is("01/22"));
+    }
+
+    @Test
+    void month02Parses() {
+        var input = "02/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("02"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, FEBRUARY)));
+        assertThat(cardExpiryDate.toString(), is("02/22"));
+    }
+
+    @Test
+    void month03Parses() {
+        var input = "03/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("03"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, MARCH)));
+        assertThat(cardExpiryDate.toString(), is("03/22"));
+    }
+
+    @Test
+    void month04Parses() {
+        var input = "04/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("04"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, APRIL)));
+        assertThat(cardExpiryDate.toString(), is("04/22"));
+    }
+
+    @Test
+    void month05Parses() {
+        var input = "05/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("05"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, MAY)));
+        assertThat(cardExpiryDate.toString(), is("05/22"));
+    }
+
+    @Test
+    void month06Parses() {
+        var input = "06/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("06"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, JUNE)));
+        assertThat(cardExpiryDate.toString(), is("06/22"));
+    }
+
+    @Test
+    void month07Parses() {
+        var input = "07/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("07"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, JULY)));
+        assertThat(cardExpiryDate.toString(), is("07/22"));
+    }
+
+    @Test
+    void month08Parses() {
+        var input = "08/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("08"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, AUGUST)));
+        assertThat(cardExpiryDate.toString(), is("08/22"));
+    }
+
+    @Test
+    void month09Parses() {
+        var input = "09/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("09"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, SEPTEMBER)));
+        assertThat(cardExpiryDate.toString(), is("09/22"));
+    }
+
+    @Test
+    void month10Parses() {
+        var input = "10/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("10"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, OCTOBER)));
+        assertThat(cardExpiryDate.toString(), is("10/22"));
+    }
+
+    @Test
+    void month11Parses() {
+        var input = "11/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("11"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, NOVEMBER)));
+        assertThat(cardExpiryDate.toString(), is("11/22"));
+    }
+
+    @Test
+    void month12Parses() {
+        var input = "12/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitMonth(), is("12"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, DECEMBER)));
+        assertThat(cardExpiryDate.toString(), is("12/22"));
+    }
+
+    @Test
+    void year22Parses() {
+        var input = "10/22";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitYear(), is("22"));
+        assertThat(cardExpiryDate.get4DigitYear(), is("2022"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2022, OCTOBER)));
+        assertThat(cardExpiryDate.toString(), is("10/22"));
+    }
+
+    @Test
+    void year00Parses() {
+        var input = "10/00";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitYear(), is("00"));
+        assertThat(cardExpiryDate.get4DigitYear(), is("2000"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2000, OCTOBER)));
+        assertThat(cardExpiryDate.toString(), is("10/00"));
+    }
+
+    @Test
+    void year01Parses() {
+        var input = "10/01";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitYear(), is("01"));
+        assertThat(cardExpiryDate.get4DigitYear(), is("2001"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2001, OCTOBER)));
+        assertThat(cardExpiryDate.toString(), is("10/01"));
+    }
+
+    @Test
+    void year09Parses() {
+        var input = "10/09";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitYear(), is("09"));
+        assertThat(cardExpiryDate.get4DigitYear(), is("2009"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2009, OCTOBER)));
+        assertThat(cardExpiryDate.toString(), is("10/09"));
+    }
+
+    @Test
+    void year30Parses() {
+        var input = "10/30";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitYear(), is("30"));
+        assertThat(cardExpiryDate.get4DigitYear(), is("2030"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2030, OCTOBER)));
+        assertThat(cardExpiryDate.toString(), is("10/30"));
+    }
+
+    @Test
+    void year99Parses() {
+        var input = "10/99";
+        var cardExpiryDate = CardExpiryDate.valueOf(input);
+        assertThat(cardExpiryDate.get2DigitYear(), is("99"));
+        assertThat(cardExpiryDate.get4DigitYear(), is("2099"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2099, OCTOBER)));
+        assertThat(cardExpiryDate.toString(), is("10/99"));
+    }
+
+    @Test
+    void month1WithNoLeadingZeroThrowsException() {
+        var input = "1/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month2WithNoLeadingZeroThrowsException() {
+        var input = "2/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month3WithNoLeadingZeroThrowsException() {
+        var input = "3/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month4WithNoLeadingZeroThrowsException() {
+        var input = "4/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month5WithNoLeadingZeroThrowsException() {
+        var input = "5/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month6WithNoLeadingZeroThrowsException() {
+        var input = "6/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month7WithNoLeadingZeroThrowsException() {
+        var input = "7/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month8WithNoLeadingZeroThrowsException() {
+        var input = "8/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month9WithNoLeadingZeroThrowsException() {
+        var input = "9/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void month13ThrowsException() {
+        var input = "13/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void threeDigitMonthThrowsException() {
+        var input = "100/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void fourDigitYearThrowsException() {
+        var input = "10/2022";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void singleDigitYearThrowsException() {
+        var input = "10/2";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void threeDigitYearThrowsException() {
+        var input = "10/222";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void missingMonthThrowsException() {
+        var input = "/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void missingYearThrowsException() {
+        var input = "10/";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void missingSlashThrowsException() {
+        var input = "1022";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void dashInsteadOfSlashThrowsException() {
+        var input = "10-22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void isoFormatThrowsException() {
+        var input = "2022-10";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void cardExpiryDatesWithSameMonthAndYearAreEqual() {
+        var cardExpiryDate1 = CardExpiryDate.valueOf("10/22");
+        var cardExpiryDate2 = CardExpiryDate.valueOf("10/22");
+        assertThat(cardExpiryDate1.equals(cardExpiryDate2), is(true));
+        assertThat(cardExpiryDate2.equals(cardExpiryDate1), is(true));
+    }
+
+    @Test
+    void cardExpiryDatesWithSameMonthAndDifferentYearAreNotEqual() {
+        var cardExpiryDate1 = CardExpiryDate.valueOf("10/22");
+        var cardExpiryDate2 = CardExpiryDate.valueOf("10/23");
+        assertThat(cardExpiryDate1.equals(cardExpiryDate2), is(false));
+        assertThat(cardExpiryDate2.equals(cardExpiryDate1), is(false));
+    }
+
+    @Test
+    void cardExpiryDatesWithDifferentMonthAndSameYearAreNotEqual() {
+        var cardExpiryDate1 = CardExpiryDate.valueOf("10/22");
+        var cardExpiryDate2 = CardExpiryDate.valueOf("11/22");
+        assertThat(cardExpiryDate1.equals(cardExpiryDate2), is(false));
+        assertThat(cardExpiryDate2.equals(cardExpiryDate1), is(false));
+    }
+
+    @Test
+    void cardExpiryDatesWithDifferentMonthAndDifferentYearAreNotEqual() {
+        var cardExpiryDate1 = CardExpiryDate.valueOf("10/22");
+        var cardExpiryDate2 = CardExpiryDate.valueOf("11/23");
+        assertThat(cardExpiryDate1.equals(cardExpiryDate2), is(false));
+        assertThat(cardExpiryDate2.equals(cardExpiryDate1), is(false));
+    }
+
+    @Test
+    void cardExpiryDateNotEqualToEquivalentString() {
+        var cardExpiryDate = CardExpiryDate.valueOf("10/22");
+        assertThat(cardExpiryDate.equals("10/22"), is(false));
+    }
+
+    @Test
+    void cardExpiryDateNotEqualToEquivalentYearMonth() {
+        var cardExpiryDate = CardExpiryDate.valueOf("10/22");
+        var yearMonth = YearMonth.of(2022, 10);
+        assertThat(cardExpiryDate.equals(yearMonth), is(false));
+    }
+
+    @Test
+    void cardExpiryDateNotEqualToNull() {
+        var cardExpiryDate = CardExpiryDate.valueOf("10/22");
+        assertThat(cardExpiryDate.equals(null), is(false));
+    }
+
+    @Test
+    void cardExpiryDatesWithSameMonthAndYearHaveSameHashCode() {
+        var cardExpiryDate1 = CardExpiryDate.valueOf("10/22");
+        var cardExpiryDate2 = CardExpiryDate.valueOf("10/22");
+        assertThat(cardExpiryDate1.hashCode(), is(cardExpiryDate2.hashCode()));
+    }
+
+}


### PR DESCRIPTION
Introduce a `CardExpiryDate` type to model card expiry dates. This is essentially a wrapper around a 2-digit month and a 2-digit year, which are the hard-working aspects of a card expiry date.

The type can be constructed from a string in MM/yy format and has a `toString()` method that converts it back to this format.

In addition, it has convenience methods to get the month as ac2-digit string and the year as a 2-digit string or a 4-digitcstring (for the latter, the 2-digit string is prefixed with "20", ingraining but also centralising and encapsulating the assumption that already pervades our system).

The type also offers a method to produce to an equivalent `YearMonth` (again, assuming the year begins with "20").

As a bonus, the type exposes a regex pattern that can be used to validate a string is in the required MM/yy format (we currently have at least 2 such regexen in our system and, no, they’re not identical in behaviour).

The type follows the convention of having a static `valueOf(String)` method that Jackson can automatically use when deserialising a JSON payload containing an expiry date in MM/yy format into a Java object. The fact that `toString()` is used to produce the MM/yy form means it also plays nicely with Jackson’s `ToStringSerializer` when going from a Java object to JSON.

The new `CardExpiryDateConverter` allows for converting from a `CardExpiryDate` to a string and vice-versa to make it easy to use `CardExpiryDate` in entities that are persisted to the database.