### PR TITLE
PP-7242 Remove stray bracket from CardExpiryDate regex

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/model/CardExpiryDate.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/CardExpiryDate.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 
 public class CardExpiryDate {
 
-    public static final Pattern CARD_EXPIRY_DATE_PATTERN = Pattern.compile("(0[1-9]|1[0-2])/([(0-9]{2})");
+    public static final Pattern CARD_EXPIRY_DATE_PATTERN = Pattern.compile("(0[1-9]|1[0-2])/([0-9]{2})");
 
     private static final String PREFIX_TO_MAKE_2_DIGIT_YEAR_INTO_4_DIGIT_YEAR = "20";
 

--- a/model/src/test/java/uk/gov/pay/commons/model/CardExpiryDateTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/CardExpiryDateTest.java
@@ -251,6 +251,18 @@ class CardExpiryDateTest {
     }
 
     @Test
+    void month00ThrowsException() {
+        var input = "00/22";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
+    void yearOpenParenthesis0ThrowsException() {
+        var input = "10/(2";
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));
+    }
+
+    @Test
     void threeDigitMonthThrowsException() {
         var input = "100/22";
         assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));


### PR DESCRIPTION
A stray bracket in the card expiry date regex meant it would accept strings like `"10/(2"`.