### PR TITLE
PP-7205 Add/modify logging keys for request logging

### DIFF
--- a/logging/src/main/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactory.java
+++ b/logging/src/main/java/uk/gov/pay/logging/GovUkPayDropwizardRequestJsonLogLayoutFactory.java
@@ -12,6 +12,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
+import static uk.gov.pay.logging.LoggingKeys.HTTP_STATUS;
+import static uk.gov.pay.logging.LoggingKeys.RESPONSE_TIME;
+import static uk.gov.pay.logging.LoggingKeys.URL;
+
 /**
  * This programmatically configures the dropwizard request log json logging to be equivalent to:
  *
@@ -40,10 +44,10 @@ public class GovUkPayDropwizardRequestJsonLogLayoutFactory extends AccessJsonLay
     private static final Map<String, String> CUSTOM_FIELD_NAMES = Map.of(
             "timestamp", "@timestamp",
             "userAgent", "user_agent",
-            "requestTime", "response_time",
-            "uri", "url",
+            "requestTime", RESPONSE_TIME,
+            "uri", URL,
             "protocol", "http_version",
-            "status", "status_code",
+            "status", HTTP_STATUS,
             "contentLength", "content_length",
             "remoteAddress", "remote_address"
     );

--- a/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
+++ b/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
@@ -127,7 +127,22 @@ public interface LoggingKeys {
     /**
      * The HTTP status we sent to a client
      */
-    String HTTP_STATUS = "http_status";
+    String HTTP_STATUS = "status_code";
+
+    /**
+     * The HTTP method for a request
+     */
+    String METHOD = "method";
+
+    /**
+     * The URL for a request
+     */
+    String URL = "url";
+
+    /**
+     * The time taken for the server to respond to a request
+     */
+    String RESPONSE_TIME = "response_time";
 
     /**
      * The HTTP status code we received from a remote server (e.g. a payment provider)


### PR DESCRIPTION
Modify the HTTP_STATUS logging key to be "status_code" as this is what
we use for request logging provided by dropwizard, and is also what we
use in our Node apps.

Have confirmed that we don't use this key anywhere in our applications
currently by doing a search in alphagov in github.

Add additional keys for "url", "method" and "response_time" so these can
be used in logging for requests that we do in addition to the dropwizard
logging. These other log lines contain additional information such as
resource ids involved in the request. Modify the dropwizard logging
template to use these keys to ensure we are consistent.