### PR TITLE
PP-7205 Move RestClientLoggingFilter to commons

### DIFF
--- a/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
+++ b/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
@@ -1,0 +1,51 @@
+package uk.gov.pay.logging;
+
+import com.google.common.base.Stopwatch;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+
+public class RestClientLoggingFilter implements ClientRequestFilter, ClientResponseFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestClientLoggingFilter.class);
+    private static final String HEADER_REQUEST_ID = "X-Request-Id";
+    private static ThreadLocal<String> requestId = new ThreadLocal<>();
+    private static ThreadLocal<Stopwatch> timer = new ThreadLocal<>();
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        timer.set(Stopwatch.createStarted());
+        requestId.set(StringUtils.defaultString(MDC.get(LoggingKeys.MDC_REQUEST_ID_KEY)));
+
+        requestContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
+        logger.info(format("[%s] - %s to %s began",
+                requestId.get(),
+                requestContext.getMethod(),
+                requestContext.getUri()));
+
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
+        long elapsed = timer.get().elapsed(TimeUnit.MILLISECONDS);
+        responseContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
+        logger.info(format("[%s] - %s to %s ended - total time %dms",
+                requestId.get(),
+                requestContext.getMethod(),
+                requestContext.getUri(),
+                elapsed));
+
+        requestId.remove();
+        timer.get().stop();
+        timer.remove();
+    }
+}

--- a/logging/src/test/java/uk/gov/pay/logging/RestClientLoggingFilterTest.java
+++ b/logging/src/test/java/uk/gov/pay/logging/RestClientLoggingFilterTest.java
@@ -1,0 +1,112 @@
+package uk.gov.pay.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class RestClientLoggingFilterTest {
+
+    private RestClientLoggingFilter loggingFilter;
+
+    @Mock
+    private ClientRequestContext clientRequestContext;
+
+    @Mock
+    private ClientResponseContext clientResponseContext;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @BeforeEach
+    public void setup() {
+        loggingFilter = new RestClientLoggingFilter();
+        Logger root = (Logger) LoggerFactory.getLogger(RestClientLoggingFilter.class);
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void shouldLogRestClientStartEventWithRequestId() {
+
+        String requestId = UUID.randomUUID().toString();
+        URI requestUrl = URI.create("/publicapi-request");
+        String requestMethod = "GET";
+        MultivaluedMap<String, Object> mockHeaders = new MultivaluedHashMap<>();
+
+        when(clientRequestContext.getUri()).thenReturn(requestUrl);
+        when(clientRequestContext.getMethod()).thenReturn(requestMethod);
+        when(clientRequestContext.getHeaders()).thenReturn(mockHeaders);
+        MDC.put(LoggingKeys.MDC_REQUEST_ID_KEY, requestId);
+
+        loggingFilter.filter(clientRequestContext);
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl)));
+
+    }
+
+    @Test
+    public void shouldLogRestClientEndEventWithRequestIdAndElapsedTime() {
+
+        String requestId = UUID.randomUUID().toString();
+        URI requestUrl = URI.create("/publicapi-request");
+        String requestMethod = "GET";
+
+        when(clientRequestContext.getUri()).thenReturn(requestUrl);
+        when(clientRequestContext.getMethod()).thenReturn(requestMethod);
+        MultivaluedMap<String, Object> mockHeaders = new MultivaluedHashMap<>();
+        MultivaluedMap<String, String> mockHeaders2 = new MultivaluedHashMap<>();
+
+        when(clientRequestContext.getHeaders()).thenReturn(mockHeaders);
+        when(clientResponseContext.getHeaders()).thenReturn(mockHeaders2);
+        MDC.put(LoggingKeys.MDC_REQUEST_ID_KEY, requestId);
+        loggingFilter.filter(clientRequestContext);
+
+        loggingFilter.filter(clientRequestContext, clientResponseContext);
+
+        verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl)));
+        String endLogMessage = loggingEvents.get(1).getFormattedMessage();
+        assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
+        String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
+        assertTrue(NumberUtils.isCreatable(timeTaken[0]));
+
+    }
+}
+


### PR DESCRIPTION
Currently this class is duplicated in publicapi, connector and products.

This can be safely moved to pay-java-commons as the request id that it
extracts from the MDC is set by LoggingFilter which is already in
pay-java-commons.