### PR TITLE
PP-7104 Log the forwarded for IP address

### DIFF
--- a/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
+++ b/logging/src/main/java/uk/gov/pay/logging/LoggingKeys.java
@@ -150,6 +150,11 @@ public interface LoggingKeys {
     String REMOTE_HTTP_STATUS = "remote_http_status";
 
     /**
+     * The Internet Protocol (IP) address of the client that sent the request.
+     */
+    String REMOTE_ADDRESS = "remote_address";
+
+    /**
      * AWS error code
      */
     String AWS_ERROR_CODE = "aws_error_code";


### PR DESCRIPTION
We were logging the `remote_address` for all Dropwizard requests, but this was logging the address of the NGINX proxy.

NGINX adds an "X-Forwarded-For" header with the original IP address that we should log instead.

Add a logging key for "remote_address", as we also want to log using this key in public api when an invalid API key is used.