### PR TITLE
Remove usage of Apache Commons lang3

### DIFF
--- a/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
+++ b/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.logging;
 
 import com.google.common.base.Stopwatch;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -11,6 +10,7 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -29,7 +29,7 @@ public class RestClientLoggingFilter implements ClientRequestFilter, ClientRespo
     @Override
     public void filter(ClientRequestContext requestContext) {
         timer.set(Stopwatch.createStarted());
-        requestId.set(StringUtils.defaultString(MDC.get(LoggingKeys.MDC_REQUEST_ID_KEY)));
+        requestId.set(Optional.ofNullable(MDC.get(LoggingKeys.MDC_REQUEST_ID_KEY)).orElse(""));
 
         requestContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
         logger.info(format("[%s] - %s to %s began",

--- a/logging/src/test/java/uk/gov/pay/logging/RestClientLoggingFilterTest.java
+++ b/logging/src/test/java/uk/gov/pay/logging/RestClientLoggingFilterTest.java
@@ -4,8 +4,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,8 +25,8 @@ import java.util.UUID;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,9 +102,7 @@ public class RestClientLoggingFilterTest {
         assertThat(loggingEvents.get(0).getFormattedMessage(), is(format("[%s] - %s to %s began", requestId, requestMethod, requestUrl)));
         String endLogMessage = loggingEvents.get(1).getFormattedMessage();
         assertThat(endLogMessage, containsString(format("[%s] - %s to %s ended - total time ", requestId, requestMethod, requestUrl)));
-        String[] timeTaken = StringUtils.substringsBetween(endLogMessage, "total time ", "ms");
-        assertTrue(NumberUtils.isCreatable(timeTaken[0]));
-
+        assertThat(endLogMessage, matchesPattern(".*total time \\d+ms"));
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,15 @@
                 <version>3.1.2</version>
                 <executions>
                     <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>false</failOnWarning>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-dependencies</id>
                         <phase>package</phase>
                         <goals>

--- a/utils/src/main/java/uk/gov/pay/commons/utils/xray/XRaySessionProfiler.java
+++ b/utils/src/main/java/uk/gov/pay/commons/utils/xray/XRaySessionProfiler.java
@@ -4,7 +4,6 @@ import com.amazonaws.xray.AWSXRay;
 import com.amazonaws.xray.AWSXRayRecorder;
 import com.amazonaws.xray.entities.Namespace;
 import com.amazonaws.xray.entities.Subsegment;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.internal.sessions.AbstractRecord;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.queries.DatabaseQuery;
@@ -89,7 +88,7 @@ public class XRaySessionProfiler implements SessionProfiler {
     private Map<String, Object> getQueryMetadata(DatabaseQuery databaseQuery) {
         Map<String, Object> databaseMetadata = new HashMap<>();
         databaseMetadata.put("preparation", databaseQuery.isCallQuery() ? "call" : "statement");
-        databaseMetadata.put("sanitized_query", StringUtils.isEmpty(databaseQuery.getSQLString()) ? "" : databaseQuery.getSQLString());
+        databaseMetadata.put("sanitized_query", Optional.ofNullable(databaseQuery.getSQLString()).orElse(""));
         return databaseMetadata;
     }
 

--- a/validation/pom.xml
+++ b/validation/pom.xml
@@ -15,11 +15,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.11</version>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>

--- a/validation/src/main/java/uk/gov/pay/commons/validation/DateValidator.java
+++ b/validation/src/main/java/uk/gov/pay/commons/validation/DateValidator.java
@@ -3,7 +3,7 @@ package uk.gov.pay.commons.validation;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.util.Optional;
 
 public class DateValidator implements ConstraintValidator<ValidDate, String> {
 
@@ -13,6 +13,7 @@ public class DateValidator implements ConstraintValidator<ValidDate, String> {
     }
 
     public static boolean isValid(String value) {
-        return isBlank(value) || DateTimeUtils.toUTCZonedDateTime(value).isPresent();
+        return Optional.ofNullable(value).orElse("").isBlank()
+                || DateTimeUtils.toUTCZonedDateTime(value).isPresent();
     }
 }


### PR DESCRIPTION
Only the validation module actually declared this dependency. We don't really
need it so let's replace it with standard Java.

Add in the dependency analyser whilst we're here.