### PR TITLE
Test the timings generated by pay-logging

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -34,11 +34,6 @@
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
-            <artifactId>jersey-guava</artifactId>
-            <version>2.25.1</version>
-        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
+++ b/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
@@ -12,8 +12,8 @@ import javax.ws.rs.client.ClientResponseFilter;
 
 import java.util.function.Supplier;
 
-import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static net.logstash.logback.marker.Markers.append;
 import static uk.gov.pay.logging.LoggingKeys.HTTP_STATUS;
 import static uk.gov.pay.logging.LoggingKeys.METHOD;
 import static uk.gov.pay.logging.LoggingKeys.RESPONSE_TIME;
@@ -42,12 +42,10 @@ public class RestClientLoggingFilter implements ClientRequestFilter, ClientRespo
         requestId.set(StringUtils.defaultString(MDC.get(LoggingKeys.MDC_REQUEST_ID_KEY)));
 
         requestContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
-        logger.info(format("[%s] - %s to %s began",
+        logger.info("[{}] - {} to {} began",
                 requestId.get(),
-                requestContext.getMethod(),
-                requestContext.getUri(),
-                kv(METHOD, requestContext.getMethod()),
-                kv(URL, requestContext.getUri())));
+                kv(METHOD, requestContext.getMethod(), requestContext.getMethod()),
+                kv(URL, requestContext.getUri(), requestContext.getUri().toString()));
 
     }
 
@@ -55,15 +53,12 @@ public class RestClientLoggingFilter implements ClientRequestFilter, ClientRespo
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
         long elapsedMs = (timeSource.get() - startTimeNs.get()) / 1_000L;
         responseContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
-        logger.info(format("[%s] - %s to %s ended - total time %dms",
+        logger.info(append(HTTP_STATUS, responseContext.getStatus()),
+                "[{}] - {} to {} ended - total time {}ms",
                 requestId.get(),
-                requestContext.getMethod(),
-                requestContext.getUri(),
-                elapsedMs),
-                kv(METHOD, requestContext.getMethod()),
-                kv(URL, requestContext.getUri()),
-                kv(HTTP_STATUS, responseContext.getStatus()),
-                kv(RESPONSE_TIME, elapsedMs));
+                kv(METHOD, requestContext.getMethod(), requestContext.getMethod()),
+                kv(URL, requestContext.getUri(), requestContext.getUri().toString()),
+                kv(RESPONSE_TIME, elapsedMs, Long.toString(elapsedMs)));
 
         requestId.remove();
         startTimeNs.remove();

--- a/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
+++ b/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.logging;
 
-import com.google.common.base.Stopwatch;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +9,8 @@ import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.client.ClientResponseContext;
 import javax.ws.rs.client.ClientResponseFilter;
-import java.util.concurrent.TimeUnit;
+
+import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -23,12 +23,22 @@ public class RestClientLoggingFilter implements ClientRequestFilter, ClientRespo
 
     private static final Logger logger = LoggerFactory.getLogger(RestClientLoggingFilter.class);
     private static final String HEADER_REQUEST_ID = "X-Request-Id";
-    private static ThreadLocal<String> requestId = new ThreadLocal<>();
-    private static ThreadLocal<Stopwatch> timer = new ThreadLocal<>();
+    private static final ThreadLocal<String> requestId = new ThreadLocal<>();
+    private static final ThreadLocal<Long> startTimeNs = new ThreadLocal<>();
+
+    private final Supplier<Long> timeSource;
+
+    public RestClientLoggingFilter() {
+        this.timeSource = System::nanoTime;
+    }
+
+    protected RestClientLoggingFilter(Supplier<Long> timeSource) {
+        this.timeSource = timeSource;
+    }
 
     @Override
     public void filter(ClientRequestContext requestContext) {
-        timer.set(Stopwatch.createStarted());
+        startTimeNs.set(timeSource.get());
         requestId.set(StringUtils.defaultString(MDC.get(LoggingKeys.MDC_REQUEST_ID_KEY)));
 
         requestContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
@@ -43,20 +53,19 @@ public class RestClientLoggingFilter implements ClientRequestFilter, ClientRespo
 
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
-        long elapsed = timer.get().elapsed(TimeUnit.MILLISECONDS);
+        long elapsedMs = (timeSource.get() - startTimeNs.get()) / 1_000L;
         responseContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
         logger.info(format("[%s] - %s to %s ended - total time %dms",
                 requestId.get(),
                 requestContext.getMethod(),
                 requestContext.getUri(),
-                elapsed),
+                elapsedMs),
                 kv(METHOD, requestContext.getMethod()),
                 kv(URL, requestContext.getUri()),
                 kv(HTTP_STATUS, responseContext.getStatus()),
-                kv(RESPONSE_TIME, elapsed));
+                kv(RESPONSE_TIME, elapsedMs));
 
         requestId.remove();
-        timer.get().stop();
-        timer.remove();
+        startTimeNs.remove();
     }
 }


### PR DESCRIPTION
Remove the strange dependency on a repackaged Guava and support injecting a mock time source for testing purposes.

This makes the tests much simpler and more deterministic.

Use of `System.nanoTime` should be adequate for any request taking under 292 years.

Also, fix a bug in structured logging. The `StructuredArgument`s were being passed to `String.format` instead of to the logger due to a misplaced parenthesis here (should be an extra closing paren on line 38): https://github.com/alphagov/pay-java-commons/blob/4ada0b0ac29e1bde7455433be071cd602c6604dc/logging/src/main/java/uk/gov/pay/logging/RestClientLoggingFilter.java#L35-L40

This likely has the effect of meaning that log entries for the start of requests were missing the method and URL structured logging attributes. Fix this by replacing `String.format` with logging placeholders and whilst we're there appease the IntelliJ linter using the techniques described here: https://github.com/logstash/logstash-logback-encoder/tree/2e98d6c74d3e19bfd6780dfe593e8b020ed7d10e#event-specific-custom-fields