### PR TITLE
PP-7590 Tweak ApiResponseDateTimeFormatter for Instants

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatter.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatter.java
@@ -1,21 +1,17 @@
 package uk.gov.pay.commons.model;
 
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
 
-/**
- * Custom ZonedDateTime formatter that will format to millisecond precision.
- * This will be padding with zeroes missing milliseconds and will drop
- * anything after the milliseconds field
- */
 public class ApiResponseDateTimeFormatter {
 
+    /**
+     * DateTimeFormatter that produces a standard ISO-8601 format date and time
+     * in UTC with millisecond precision (three fractional second digits, zero
+     * right-padded if necessary), for example 2015-10-21T07:28:00.000Z
+     */
     public static final DateTimeFormatter ISO_INSTANT_MILLISECOND_PRECISION =
-            new DateTimeFormatterBuilder()
-                    .appendInstant(3)
-                    .toFormatter(Locale.ENGLISH)
-                    .withZone(ZoneOffset.UTC);
+            new DateTimeFormatterBuilder().appendInstant(3).toFormatter(Locale.ENGLISH);
 
 }

--- a/model/src/test/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatterTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/model/ApiResponseDateTimeFormatterTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.commons.model;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -13,11 +14,29 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class ApiResponseDateTimeFormatterTest {
+class ApiResponseDateTimeFormatterTest {
 
     @Test
-    public void shouldConvertUtcToIsoStringWithMillisecondPrecision() {
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
+    void shouldConvertInstantToIsoStringWithMillisecondPrecision() {
+        var instant = Instant.parse("2015-10-21T07:28:00.12356789Z");
+
+        String result = ISO_INSTANT_MILLISECOND_PRECISION.format(instant);
+
+        assertThat(result, is("2015-10-21T07:28:00.123Z"));
+    }
+
+    @Test
+    void shouldConverInstantExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
+        var instant = Instant.parse("2015-10-21T07:28:00Z");
+
+        String result = ISO_INSTANT_MILLISECOND_PRECISION.format(instant);
+
+        assertThat(result, is("2015-10-21T07:28:00.000Z"));
+    }
+    
+    @Test
+    void shouldConvertUtcZonedDateTimeToIsoStringWithMillisecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
                 LocalTime.of(7, 28, 0, 123456789), ZoneOffset.UTC);
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
@@ -26,8 +45,8 @@ public class ApiResponseDateTimeFormatterTest {
     }
 
     @Test
-    public void shouldConvertNonUtcToIsoStringWithMillisecondPrecision() {
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
+    void shouldConvertNonUtcZonedDateTimeToIsoStringWithMillisecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
                 LocalTime.of(7, 28, 0, 123456789), ZoneId.of("America/Los_Angeles"));
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
@@ -36,8 +55,8 @@ public class ApiResponseDateTimeFormatterTest {
     }
 
     @Test
-    public void shouldConvertExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
-        ZonedDateTime zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
+    void shouldConvertZonedDateTimeExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
                 LocalTime.of(7, 28, 0), ZoneOffset.UTC);
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);


### PR DESCRIPTION
Update Javadoc for `ApiResponseDateTimeFormatter` to clarify it’s not just for `ZonedDateTime`s, moving the Javadoc to the `DateTimeFormatter` field rather than its containing class.

Add some tests to demonstrate that `ApiResponseDateTimeFormatter` works for Instants.

Do not set a time zone on the `DateTimeFormatterBuilder` because it’s never actually used (appending an ISO instant to a `DateTimeFormatterBuilder` always adds it using UTC). This does not change how dates and times are formatted.