### PR TITLE
PP-7590 Add JSON serialiser for Instants

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/api/json/ApiResponseInstantSerializer.java
+++ b/model/src/main/java/uk/gov/pay/commons/api/json/ApiResponseInstantSerializer.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ApiResponseInstantSerializer extends StdSerializer<Instant> {
+
+    public ApiResponseInstantSerializer() {
+        this(null);
+    }
+
+    private ApiResponseInstantSerializer(Class<Instant> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Instant value, JsonGenerator gen, SerializerProvider sp) throws IOException {
+        gen.writeString(ISO_INSTANT_MILLISECOND_PRECISION.format(value));
+    }
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseInstantSerializerTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/api/json/ApiResponseInstantSerializerTest.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+class ApiResponseInstantSerializerTest {
+
+    private final ApiResponseInstantSerializer apiResponseInstantSerializer = new ApiResponseInstantSerializer();
+
+    @Test
+    void shouldSerializeWithMillisecondPrecision() throws IOException {
+        var instant = Instant.parse("2020-12-25T15:00:00.123456789Z");
+
+        var stringWriter = new StringWriter();
+        var jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+
+        apiResponseInstantSerializer.serialize(instant, jsonGenerator, new ObjectMapper().getSerializerProvider());
+        jsonGenerator.flush();
+
+        var expected = "\"2020-12-25T15:00:00.123Z\"";
+        var actual = stringWriter.toString();
+
+        assertThat(actual, is(expected));
+    }
+
+}


### PR DESCRIPTION
`ApiResponseInstantSerializer` is to `Instant`s what `ApiResponseDateTimeSerializer` is to `ZonedDateTime`s.