### PR TITLE
PP-7590 JPA converter to convert between Instant and LocalDateTime

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/jpa/InstantToUtcTimestampWithoutTimeZoneConverter.java
+++ b/model/src/main/java/uk/gov/pay/commons/jpa/InstantToUtcTimestampWithoutTimeZoneConverter.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.commons.jpa;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * Converts an Instant to a LocalDateTime using UTC as the assumed local time
+ * zone. Per JDBC 4.2, this LocalDateTime can then be stored in a database
+ * column of type TIMESTAMP WITHOUT TIME ZONE.
+ * 
+ * Alternatively, takes a LocalDateTime read from a database column of type
+ * TIMESTAMP WITHOUT TIME ZONE and converts it into an Instant by assuming it
+ * refers to a date and time in the UTC time zone.
+ **/
+@Converter
+public class InstantToUtcTimestampWithoutTimeZoneConverter implements AttributeConverter<Instant, LocalDateTime> {
+
+    @Override
+    public LocalDateTime convertToDatabaseColumn(Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+
+        return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+    }
+
+    @Override
+    public Instant convertToEntityAttribute(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return null;
+        }
+
+        return localDateTime.toInstant(ZoneOffset.UTC);
+    }
+
+}

--- a/model/src/test/java/uk/gov/pay/commons/jpa/InstantToUtcTimestampWithoutTimeZoneConverterTest.java
+++ b/model/src/test/java/uk/gov/pay/commons/jpa/InstantToUtcTimestampWithoutTimeZoneConverterTest.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.commons.jpa;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+class InstantToUtcTimestampWithoutTimeZoneConverterTest {
+
+    private final InstantToUtcTimestampWithoutTimeZoneConverter converter = new InstantToUtcTimestampWithoutTimeZoneConverter();
+
+    @Test
+    void convertsInstantToLocalDateTimeInUtc() {
+        var instant = Instant.parse("2020-12-25T15:00:00.123456789Z");
+        LocalDateTime result = converter.convertToDatabaseColumn(instant);
+        assertThat(result, is(LocalDateTime.of(2020, 12, 25, 15, 0, 0, 123456789)));
+    }
+
+    @Test
+    void convertsNullInstantToNull() {
+        LocalDateTime result = converter.convertToDatabaseColumn(null);
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    void convertsLocalDateTimeToInstant() {
+        var localDateTime = LocalDateTime.of(2020, 12, 25, 15, 0, 0, 123456789);
+        Instant result = converter.convertToEntityAttribute(localDateTime);
+        assertThat(result, is(Instant.parse("2020-12-25T15:00:00.123456789Z")));
+    }
+
+    @Test
+    void convertsNullLocalDateTimeToNull() {
+        Instant result = converter.convertToEntityAttribute(null);
+        assertThat(result, is(nullValue()));
+    }
+
+}


### PR DESCRIPTION
Add a JPA `AttributeConverter` that converts between an `Instant` entity attribute and a `LocalDateTime` (assumed to be in UTC) for storing in a database column and vice versa.

Per JDBC 4.2, `LocalDateTime` maps to database columns of the type `TIMESTAMP WITHOUT TIME ZONE`.

This class is intended to be a replacement for `UTCDateTimeConverter` (found in connector and other services) except that it works with `Instant`s rather than `ZonedDateTime`s.

Contrary to its name, `UTCDateTimeConverter`’s actually stores dates and times in the database using the default time zone.
The input `ZonedDateTime` gets converted to a `Timestamp`, which is effectively just a count of nanoseconds since the epoch. The database driver then has to store this `Timestamp` in a `TIMESTAMP WITHOUT TIME ZONE` database column. It does this by converting the `Timestamp` into the equivalent local date and time in the default time zone. This is fine if the default time zone is UTC. However, if the default time zone is, say, Europe/London and it’s British Summer Time then all times will be shifted forward an hour and 10:00 will become 11:00.

This class can also replace connector’s `LocalDateTimeConverter` (again, except that it works with `Instant`s rather than `ZonedDateTime`s), which was created to work like `UTCDateTimeConverter` but without the default time zone issue.

Since both `LocalDateTime` and `TIMESTAMP WITHOUT TIME ZONE` are just dates and times with no time zone information, the default time zone is not required to convert between one and the other.[1]

Since our production Java servers have always used UTC as their default time zone, there will be no change to how existing
dates and times in the database are interpreted. There may be changes in environments that use a different default time zone, such as developer machines, but such environments will only have unimportant test data.

If we ever change our database columns to be of type `TIMESTAMP WITH TIME ZONE` (which some would recommend), we would have to use a converter that works with `OffsetDateTime`s instead of `LocalDateTime`s.

[1] Unfortunately, this is not actually true. The PostgreSQL JDBC driver does actually use the default time zone when storing a `LocalDateTime` in a `TIMESTAMP WITHOUT TIME ZONE` database column.[2] However, this only causes the date and time to be changed if the `LocalDateTime` falls in an hour that doesn’t exist in the default time zone (e.g. the hour that’s skipped when the clocks go forward). Fortunately, this doesn’t happen very often.

[2] See https://github.com/pgjdbc/pgjdbc/issues/1390#issuecomment-698631932 for my attempt to persuade the developers to make it not do this.