### PR TITLE
PP-7696 Add CARD_AGENT_INITIATED_MOTO to Source enum

### DIFF
--- a/model/src/main/java/uk/gov/pay/commons/model/Source.java
+++ b/model/src/main/java/uk/gov/pay/commons/model/Source.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 public enum Source {
     CARD_API,
     CARD_PAYMENT_LINK,
+    CARD_AGENT_INITIATED_MOTO,
     CARD_EXTERNAL_TELEPHONE;
 
     public static Optional<Source> from(String sourceName) {


### PR DESCRIPTION
Add `CARD_AGENT_INITIATED_MOTO` to the `Source` enum to join its friends `CARD_API`, `CARD_PAYMENT_LINK` and `CARD_EXTERNAL_TELEPHONE`.

`CARD_AGENT_INITIATED_MOTO` means the payment was created from an `AGENT_INITIATED_MOTO` product.