### PR TITLE
Pp 7938 release to maven

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,23 @@
+name: Release to maven
+on:
+  push:
+    branches:
+      - PP-7938-release-to-maven
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+      - name: Install Java and Maven
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Release Maven package
+        uses: samuelmeuli/action-maven-publish@v1
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          nexus_username: ${{ secrets.MAVEN_USERNAME }}
+          nexus_password: ${{ secrets.MAVEN_PASSWORD }}
+          server_id: ossrh

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,7 +15,7 @@ jobs:
           java-version: 11
       - name: Set package version
         run: |
-          mvn versions:set -DnewVersion="1.0.0-$(date +"%Y%m%d%H%M%S")"
+          mvn versions:set -DnewVersion="1.0.$(date +"%Y%m%d%H%M%S")"
       - name: Release Maven package
         uses: samuelmeuli/action-maven-publish@v1
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -2,7 +2,7 @@ name: Release to maven
 on:
   push:
     branches:
-      - PP-7938-release-to-maven
+      - master
 jobs:
   release:
     runs-on: ubuntu-18.04
@@ -13,6 +13,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Set package version
+        run: |
+          mvn versions:set -DnewVersion="1.0.0-$(date +"%Y%m%d%H%M%S")"
       - name: Release Maven package
         uses: samuelmeuli/action-maven-publish@v1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,26 @@
     <artifactId>pay-java-commons</artifactId>
     <version>1.0.0</version>
     <packaging>pom</packaging>
+    <description>Common functionality for GOV.UK Pay Java repositories</description>
+    <url>https://github.com/alphagov/pay-java-commons/</url>
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:git@github.com:alphagov/pay-java-commons.git</connection>
+        <developerConnection>scm:git:git@github.com:alphagov/pay-java-commons.git</developerConnection>
+        <url>git@github.com:alphagov/pay-java-commons.git</url>
+        <tag>HEAD</tag>
+    </scm>
+    <developers>
+        <developer>
+            <name>GOV.UK Pay</name>
+            <email>govuk-pay-support@digital.cabinet-office.gov.uk</email>
+        </developer>
+    </developers>
 
     <name>GOV.UK Pay Java common repository</name>
 
@@ -16,8 +36,6 @@
         <junit5.version>5.6.2</junit5.version>
         <assertj.version>1.7.25</assertj.version>
         <jackson.version>2.11.1</jackson.version>
-        <bintray.username/>
-        <bintray.apiKey/>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
@@ -153,14 +171,81 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>deploy</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Prevent `gpg` from using pinentry programs -->
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <distributionManagement>
         <repository>
-            <id>bintray-govuk-pay-pay-java-commons</id>
-            <name>govuk-pay-pay-java-commons</name>
-            <url>https://api.bintray.com/maven/govuk-pay/pay-java-commons/pay-java-commons/;publish=1</url>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <version>2.9.1</version>
                 <executions>
                     <execution>

--- a/validation/src/main/java/uk/gov/service/payments/commons/validation/DateTimeUtils.java
+++ b/validation/src/main/java/uk/gov/service/payments/commons/validation/DateTimeUtils.java
@@ -15,15 +15,14 @@ public class DateTimeUtils {
 
     /**
      * Converts any valid ZonedDateTime String (ISO_8601) representation to a UTC ZonedDateTime
-     * <p>
-     * e.g. <br/>
-     * 1. 2010-01-01T12:00:00+01:00[Europe/Paris] ==>  ZonedDateTime("2010-12-31T22:59:59.132Z") <br/>
-     * 2. 2010-12-31T22:59:59.132Z ==>  ZonedDateTime("2010-12-31T22:59:59.132Z") <br/>
-     * </p>
+     *
+     * e.g. 
+     * 1. 2010-01-01T12:00:00+01:00[Europe/Paris] to ZonedDateTime("2010-12-31T22:59:59.132Z")
+     * 2. 2010-12-31T22:59:59.132Z to ZonedDateTime("2010-12-31T22:59:59.132Z")
      *
      * @param dateString e.g.
-     * @return @ZonedDateTime instance represented by dateString in UTC ("Z") or
-     * @Optional.empty() if the dateString does not represent a valid ISO_8601 zone string
+     * @return ZonedDateTime instance represented by dateString in UTC ("Z") or
+     * Optional.empty() if the dateString does not represent a valid ISO_8601 zone string
      * @see "https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html"
      */
     public static Optional<ZonedDateTime> toUTCZonedDateTime(String dateString) {
@@ -39,11 +38,11 @@ public class DateTimeUtils {
 
     /**
      * Converts a LocalDateTime to a UTC ISO_8601 string representation
-     * <p>
-     * e.g. <br/>
-     * 1. LocalDateTime("2010-01-01") ==> "2010-12-01" <br/>
-     * 2. LocalDateTime("2010-12-31") ==> "2010-12-31" <br/>
-     * </p>
+     *
+     * e.g.
+     * 1. LocalDateTime("2010-01-01") to "2010-12-01"
+     * 2. LocalDateTime("2010-12-31") to "2010-12-31"
+     *
      *
      * @param zonedDateTime
      * @return UTC ISO_8601 date string


### PR DESCRIPTION
Release pay-java-commons. Example of a successful release [here](https://www.bbc.co.uk/weather/2643743). This release follows the current convention we have, which is `1.0.yyyyMMddHHMMSS`.
See https://repo1.maven.org/maven2/uk/gov/service/payments/ for successfully released versions!
We should be able to search for our packages in https://search.maven.org/search?q=g:uk.gov.service.payments before merging this PR.
We will tackle removing bintray related stuff in another PR.