### PR TITLE
PP-8551 Move JSON Patch classes to commons

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/model/src/main/java/uk/gov/service/payments/commons/api/exception/ValidationException.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/exception/ValidationException.java
@@ -1,0 +1,16 @@
+package uk.gov.service.payments.commons.api.exception;
+
+import java.util.List;
+
+public class ValidationException extends RuntimeException {
+    
+    private List<String> errors;
+
+    public ValidationException(List<String> errors) {
+        this.errors = errors;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/JsonMapper.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/JsonMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.service.payments.commons.api.json;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+public class JsonMapper {
+    private ObjectMapper objectMapper;
+    
+    public JsonMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Map<String, String> getAsMap(JsonNode jsonNode) {
+        if (jsonNode != null) {
+            if ((jsonNode.isTextual() && !isEmpty(jsonNode.asText())) || (!jsonNode.isNull() && jsonNode.isObject())) {
+                try {
+                    return objectMapper.readValue(jsonNode.traverse(), new TypeReference<Map<String, String>>() {});
+                } catch (IOException e) {
+                    throw new RuntimeException("Malformed JSON object in value", e);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidator.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidator.java
@@ -1,0 +1,87 @@
+package uk.gov.service.payments.commons.api.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.service.payments.commons.api.exception.ValidationException;
+import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchOp;
+import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static uk.gov.service.payments.commons.model.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
+import static uk.gov.service.payments.commons.model.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
+import static uk.gov.service.payments.commons.model.jsonpatch.JsonPatchKeys.FIELD_VALUE;
+
+public class JsonPatchRequestValidator {
+
+    private static final Set<String> allowedOps = Arrays.stream(JsonPatchOp.values())
+            .map(jsonPatchOp -> jsonPatchOp.name().toLowerCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+
+    private final Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators;
+
+    public JsonPatchRequestValidator(Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators) {
+        this.operationValidators = operationValidators;
+    }
+
+    public void validate(JsonNode payload) {
+        if (!payload.isArray()) {
+            throw new ValidationException(Collections.singletonList("JSON is not an array"));
+        }
+
+        for (JsonNode jsonNode : payload) {
+            List<String> fieldErrors = RequestValidator.checkIfExistsOrEmpty(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH, FIELD_VALUE);
+            if (!fieldErrors.isEmpty()) {
+                throw new ValidationException(fieldErrors);
+            }
+
+            List<String> opPathTypeErrors = RequestValidator.checkIsString(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH);
+            if (!opPathTypeErrors.isEmpty()) {
+                throw new ValidationException(opPathTypeErrors);
+            }
+
+            String op = jsonNode.get(FIELD_OPERATION).asText();
+            List<String> opErrors = RequestValidator.checkIsAllowedValue(jsonNode, allowedOps, FIELD_OPERATION);
+            if (!opErrors.isEmpty()) {
+                throw new ValidationException(opErrors);
+            }
+
+            JsonPatchOp jsonPatchOp = JsonPatchOp.valueOf(op.toUpperCase());
+
+            String path = jsonNode.get(FIELD_OPERATION_PATH).asText();
+            Set<String> allowedPaths = operationValidators.keySet().stream().map(PatchPathOperation::getPath).collect(Collectors.toSet());
+
+            List<String> pathErrors = RequestValidator.checkIsAllowedValue(jsonNode, allowedPaths, FIELD_OPERATION_PATH);
+            if (!pathErrors.isEmpty()) {
+                throw new ValidationException(pathErrors);
+            }
+
+            PatchPathOperation pathOperation = new PatchPathOperation(path, jsonPatchOp);
+            if (!operationValidators.containsKey(pathOperation)) {
+                throw new ValidationException(Collections.singletonList(format("Operation [%s] not supported for path [%s]", op, path)));
+            }
+
+            JsonPatchRequest request = JsonPatchRequest.from(jsonNode);
+            operationValidators.get(pathOperation).accept(request);
+        }
+    }
+
+    public static void throwIfValueNotString(JsonPatchRequest request) {
+        if (!request.valueIsString()) {
+            throw new ValidationException(Collections.singletonList(format("Value for path [%s] must be a string", request.getPath())));
+        }
+    }
+
+    public static void throwIfValueNotBoolean(JsonPatchRequest request) {
+        if (!request.valueIsBoolean()) {
+            throw new ValidationException(Collections.singletonList(format("Value for path [%s] must be a boolean", request.getPath())));
+        }
+    }
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/PatchPathOperation.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/PatchPathOperation.java
@@ -1,0 +1,36 @@
+package uk.gov.service.payments.commons.api.validation;
+
+import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchOp;
+
+import java.util.Objects;
+
+public class PatchPathOperation {
+    private final String path;
+    private final JsonPatchOp operation;
+
+    public PatchPathOperation(String path, JsonPatchOp operation) {
+        this.path = path;
+        this.operation = operation;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public JsonPatchOp getOperation() {
+        return operation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PatchPathOperation that = (PatchPathOperation) o;
+        return Objects.equals(path, that.path) && Objects.equals(operation, that.operation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, operation);
+    }
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/RequestValidator.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/RequestValidator.java
@@ -1,0 +1,116 @@
+package uk.gov.service.payments.commons.api.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.math.NumberUtils.isDigits;
+
+public class RequestValidator {
+
+    public static List<String> checkIsNumeric(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotNumeric(), fieldNames, "Field [%s] must be a number");
+    }
+
+    public static List<String> checkIsBoolean(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotBoolean(), fieldNames, "Field [%s] must be a boolean");
+    }
+
+    public static List<String> checkIsString(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotString(), fieldNames, "Field [%s] must be a string");
+    }
+
+    public static List<String> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, notExistOrEmpty(), fieldNames, "Field [%s] is required");
+    }
+
+    public static List<String> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {
+        return applyCheck(payload, exceedsMaxLength(maxLength), fieldNames, "Field [%s] must have a maximum length of " + maxLength + " characters");
+    }
+
+    public static List<String> checkIsAllowedValue(JsonNode payload, Set<String> allowedValues, String... fieldNames) {
+        return applyCheck(payload, isNotAllowedValue(allowedValues), fieldNames, "Field [%s] must be one of "
+                + allowedValues.stream().sorted().collect(Collectors.joining(", ", "[", "]")));
+    }
+
+    private static List<String> applyCheck(JsonNode payload, Function<JsonNode, Boolean> check, String[] fieldNames, String errorMessage) {
+        List<String> errors = new ArrayList<>();
+        for (String fieldName : fieldNames) {
+            if (check.apply(payload.get(fieldName))) {
+                errors.add(format(errorMessage, fieldName));
+            }
+        }
+        return errors;
+    }
+
+    private static Function<JsonNode, Boolean> exceedsMaxLength(int maxLength) {
+        return jsonNode -> jsonNode.asText().length() > maxLength;
+    }
+
+    private static Function<JsonNode, Boolean> notExistOrEmpty() {
+        return (jsonElement) -> {
+            if (jsonElement instanceof NullNode) {
+                return isNullValue().apply(jsonElement);
+            } else if (jsonElement instanceof ArrayNode) {
+                return notExistOrEmptyArray().apply(jsonElement);
+            } else if (jsonElement instanceof ObjectNode) {
+                return notExistOrEmptyObject().apply(jsonElement);
+            } else {
+                return notExistOrBlankText().apply(jsonElement);
+            }
+        };
+    }
+
+    private static Function<JsonNode, Boolean> notExistOrEmptyArray() {
+        return jsonElement -> (
+                jsonElement == null ||
+                        ((jsonElement instanceof ArrayNode) && (jsonElement.size() == 0))
+        );
+    }
+
+    private static Function<JsonNode, Boolean> notExistOrEmptyObject() {
+        return jsonElement -> (
+                jsonElement == null ||
+                        ((jsonElement instanceof ObjectNode) && jsonElement.isEmpty())
+        );
+    }
+
+    private static Function<JsonNode, Boolean> notExistOrBlankText() {
+        return jsonElement -> (
+                jsonElement == null ||
+                        isBlank(jsonElement.asText())
+        );
+    }
+
+    private static Function<JsonNode, Boolean> isNullValue() {
+        return jsonElement -> (
+                jsonElement == null || jsonElement.isNull()
+        );
+    }
+
+    private static Function<JsonNode, Boolean> isNotNumeric() {
+        return jsonNode -> !isDigits(jsonNode.asText());
+    }
+
+    private static Function<JsonNode, Boolean> isNotBoolean() {
+        return jsonNode -> jsonNode == null || !jsonNode.isBoolean();
+    }
+
+    private static Function<JsonNode, Boolean> isNotAllowedValue(Set<String> allowedValues) {
+        return jsonNode -> jsonNode == null || !allowedValues.contains(jsonNode.asText());
+    }
+
+    private static Function<JsonNode, Boolean> isNotString() {
+        return jsonNode -> !jsonNode.isTextual();
+    }
+
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchKeys.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchKeys.java
@@ -1,0 +1,9 @@
+package uk.gov.service.payments.commons.model.jsonpatch;
+
+public interface JsonPatchKeys {
+
+    String FIELD_OPERATION = "op";
+    String FIELD_OPERATION_PATH = "path";
+    String FIELD_VALUE = "value";
+
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchOp.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchOp.java
@@ -1,0 +1,7 @@
+package uk.gov.service.payments.commons.model.jsonpatch;
+
+public enum JsonPatchOp {
+    ADD,
+    REPLACE,
+    REMOVE
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchRequest.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchRequest.java
@@ -1,0 +1,101 @@
+package uk.gov.service.payments.commons.model.jsonpatch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.service.payments.commons.api.json.JsonMapper;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.service.payments.commons.model.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
+import static uk.gov.service.payments.commons.model.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
+import static uk.gov.service.payments.commons.model.jsonpatch.JsonPatchKeys.FIELD_VALUE;
+
+public class JsonPatchRequest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final JsonMapper jsonObjectMapper = new JsonMapper(objectMapper);
+    
+    private final JsonPatchOp op;
+    private final String path;
+    private final JsonNode value;
+
+    public JsonPatchOp getOp() {
+        return op;
+    }
+
+    public String getPath() {
+        return path;
+    }
+    
+    public boolean valueIsString() { 
+        return value.isTextual();
+    }
+
+    public boolean valueIsBoolean() {
+        return value.isBoolean();
+    }
+
+    public String valueAsString() {
+        return value.asText();
+    }
+    
+    public long valueAsLong() {
+        if (value != null && value.isNumber()) {
+            return Long.parseLong(value.asText());
+        }
+        throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type number");
+    }
+    
+    public int valueAsInt() {
+        if(value != null && value.isNumber()) {
+            return Integer.parseInt(value.asText());
+        }
+        throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type number");
+    }
+
+    public boolean valueAsBoolean() {
+        if (value != null && value.isBoolean()) {
+            return Boolean.parseBoolean(value.asText());
+        }
+        throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type boolean");
+    }
+
+    public Map<String, String> valueAsObject() {
+        return jsonObjectMapper.getAsMap(value);
+    }
+
+
+    private JsonPatchRequest(JsonPatchOp op, String path, JsonNode value) {
+        this.op = op;
+        this.path = path;
+        this.value = value;
+    }
+
+    public static JsonPatchRequest from(JsonNode payload) {
+        return new JsonPatchRequest(
+                JsonPatchOp.valueOf(payload.get(FIELD_OPERATION).asText().toUpperCase()),
+                payload.get(FIELD_OPERATION_PATH).asText(),
+                payload.get(FIELD_VALUE));
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JsonPatchRequest that = (JsonPatchRequest) o;
+        return op == that.op && Objects.equals(path, that.path) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(op, path, value);
+    }
+
+    public class JsonNodeNotCorrectTypeException extends RuntimeException {
+        public JsonNodeNotCorrectTypeException(String message) {
+            super(message);
+        }
+    }
+}

--- a/model/src/test/java/uk/gov/service/payments/commons/api/json/JsonMapperTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/api/json/JsonMapperTest.java
@@ -1,0 +1,23 @@
+package uk.gov.service.payments.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+
+public class JsonMapperTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonMapper jsonObjectMapper = new JsonMapper(objectMapper);
+    
+    @Test
+    public void shouldMapToMap() throws JsonProcessingException {
+        JsonNode jsonNode = objectMapper.readTree("{\"foo\":\"bar\"}");
+        Map<String, String> fromJson = jsonObjectMapper.getAsMap(jsonNode);
+        assertThat(fromJson, hasEntry("foo", "bar"));
+    }
+}

--- a/model/src/test/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidatorTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidatorTest.java
@@ -1,0 +1,134 @@
+package uk.gov.service.payments.commons.api.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import uk.gov.service.payments.commons.api.exception.ValidationException;
+import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchOp;
+import uk.gov.service.payments.commons.model.jsonpatch.JsonPatchRequest;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class JsonPatchRequestValidatorTest {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    static class InvalidValuesTestProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    Arguments.of("Field [path] is required", buildPatchRequest(Map.of("operation", "add", "value", true))),
+                    Arguments.of("Field [path] is required", buildPatchRequest(Map.of("operation", "add", "path", "", "value", true))),
+                    Arguments.of("Field [path] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", "add");
+                        put("path", null);
+                        put("value", true);
+                    }})),
+                    Arguments.of("Field [path] must be a string", buildPatchRequest(Map.of("operation", "add", "path", 1234, "value", true))),
+
+                    Arguments.of("Field [op] is required", buildPatchRequest(Map.of("path", "foo", "value", true))),
+                    Arguments.of("Field [op] is required", buildPatchRequest(Map.of("operation", "", "path", "foo", "value", true))),
+                    Arguments.of("Field [op] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", null);
+                        put("path", "foo");
+                        put("value", true);
+                    }})),
+                    Arguments.of("Field [op] must be a string", buildPatchRequest(Map.of("operation", 1234, "path", "foo", "value", true))),
+                    Arguments.of("Field [op] must be one of [add, remove, replace]", buildPatchRequest(Map.of("operation", "cook", "path", "foo", "value", true))),
+
+                    Arguments.of("Field [value] is required", buildPatchRequest(Map.of("operation", "add", "path", "foo"))),
+                    Arguments.of("Field [value] is required", buildPatchRequest(Map.of("operation", "add", "path", "foo", "value", ""))),
+                    Arguments.of("Field [value] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", "add");
+                        put("path", "foo");
+                        put("value", null);
+                    }})),
+                    Arguments.of("Field [value] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", "add");
+                        put("path", "foo");
+                        put("value", Map.of());
+                    }})),
+
+                    Arguments.of("Field [path] must be one of [bar, foo]", buildPatchRequest(Map.of("operation", "add", "path", "baz", "value", true))),
+                    Arguments.of("Operation [replace] not supported for path [foo]", buildPatchRequest(Map.of("operation", "replace", "path", "foo", "value", true)))
+            );
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(InvalidValuesTestProvider.class)
+    void shouldThrowExceptionWhenValidationFails(String expectedErrorMessage, JsonNode request) {
+        Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators = Map.of(
+                new PatchPathOperation("foo", JsonPatchOp.ADD), (node) -> {},
+                new PatchPathOperation("bar", JsonPatchOp.REPLACE), (node) -> {}
+        );
+
+        var patchRequestValidator = new JsonPatchRequestValidator(operationValidators);
+        ValidationException validationException = assertThrows(ValidationException.class,
+                () -> patchRequestValidator.validate(request));
+
+        assertThat(validationException, hasProperty("errors", contains(expectedErrorMessage)));
+    }
+
+    @Test
+    void shouldSucceedForValidRequestAndCallOperationValidator() {
+        JsonNode fooOperation = objectMapper.valueToTree(Map.of("path", "foo",
+                "op", "add",
+                "value", 1));
+        JsonNode barOperation = objectMapper.valueToTree(Map.of("path", "bar",
+                "op", "replace",
+                "value", 1));
+        JsonNode request = objectMapper.valueToTree(List.of(fooOperation, barOperation));
+
+        Consumer<JsonPatchRequest> addFooValidator = mock(Consumer.class);
+        doAnswer((node) -> null).when(addFooValidator).accept(eq(JsonPatchRequest.from(fooOperation)));
+
+        Consumer<JsonPatchRequest> replaceBarValidator = mock(Consumer.class);
+        doAnswer((node) -> null).when(replaceBarValidator).accept(eq(JsonPatchRequest.from(barOperation)));
+
+        Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators = Map.of(
+                new PatchPathOperation("foo", JsonPatchOp.ADD), addFooValidator,
+                new PatchPathOperation("bar", JsonPatchOp.REPLACE), replaceBarValidator
+        );
+
+        var patchRequestValidator = new JsonPatchRequestValidator(operationValidators);
+
+        patchRequestValidator.validate(request);
+        verify(addFooValidator).accept(eq(JsonPatchRequest.from(fooOperation)));
+        verify(replaceBarValidator).accept(eq(JsonPatchRequest.from(barOperation)));
+    }
+
+    private static JsonNode buildPatchRequest(Map<Object, Object> data) {
+        Map<Object, Object> params = new HashMap<>();
+        if (data.containsKey("operation")) {
+            params.put("op", data.get("operation"));
+        }
+        if (data.containsKey("path")) {
+            params.put("path", data.get("path"));
+        }
+        if (data.containsKey("value")) {
+            params.put("value", data.get("value"));
+        }
+
+        return objectMapper.valueToTree(Collections.singletonList(params));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <junit5.version>5.6.2</junit5.version>
         <assertj.version>1.7.25</assertj.version>
         <jackson.version>2.12.4</jackson.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
@@ -76,6 +77,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
These existed in connector. Move to commons so they can be reused in products.