### PR TITLE
PP-8496: Add methods to handle arrays in JSON Patch operations

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidator.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidator.java
@@ -83,5 +83,11 @@ public class JsonPatchRequestValidator {
         if (!request.valueIsBoolean()) {
             throw new ValidationException(Collections.singletonList(format("Value for path [%s] must be a boolean", request.getPath())));
         }
+    }    
+    
+    public static void throwIfValueNotArray(JsonPatchRequest request) {
+        if (!request.valueIsArray()) {
+            throw new ValidationException(Collections.singletonList(format("Value for path [%s] must be an array", request.getPath())));
+        }
     }
 }

--- a/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchRequest.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/jsonpatch/JsonPatchRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.service.payments.commons.api.json.JsonMapper;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -32,12 +33,20 @@ public class JsonPatchRequest {
         return value.isTextual();
     }
 
+    public boolean valueIsArray() {
+        return value.isArray();
+    }
+
     public boolean valueIsBoolean() {
         return value.isBoolean();
     }
 
     public String valueAsString() {
         return value.asText();
+    }
+
+    public List valueAsList() {
+        return objectMapper.convertValue(value, List.class);
     }
     
     public long valueAsLong() {


### PR DESCRIPTION
As part of Webhooks work we would like to JSON Patch an array value. This adds some methods to make that easier.