### PR TITLE
PP-8496: remove emptiness check for json patch value attribute

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidator.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/JsonPatchRequestValidator.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static uk.gov.service.payments.commons.model.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
@@ -37,7 +38,9 @@ public class JsonPatchRequestValidator {
         }
 
         for (JsonNode jsonNode : payload) {
-            List<String> fieldErrors = RequestValidator.checkIfExistsOrEmpty(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH, FIELD_VALUE);
+            List<String> fieldErrors = Stream.concat(RequestValidator.checkIfExistsOrEmpty(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH).stream(),
+                            RequestValidator.checkIfNull(jsonNode, FIELD_VALUE).stream())
+                    .collect(Collectors.toList());
             if (!fieldErrors.isEmpty()) {
                 throw new ValidationException(fieldErrors);
             }

--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/RequestValidator.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/RequestValidator.java
@@ -31,6 +31,10 @@ public class RequestValidator {
 
     public static List<String> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, notExistOrEmpty(), fieldNames, "Field [%s] is required");
+    }    
+    
+    public static List<String> checkIfNull(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNullValue(), fieldNames, "Field [%s] is required");
     }
 
     public static List<String> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {


### PR DESCRIPTION
Previously we were enforcing that a json patch value can not be an empty value. This is overly restrictive, as empty string is a valid value for an add or replace operation.

Note: this is a change in behaviour for existing library users. However, I believe the risk of regressions is low, as a per-field additional validation is required in which clients are likely to set any explicit requirements for the field.