### PR TITLE
Revert "Bump nexus-staging-maven-plugin from 1.6.8 to 1.6.10"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.10</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
Breaking publishing
Reverts alphagov/pay-java-commons#400