### PR TITLE
PP-6565 Add logging key for disputes

### DIFF
--- a/logging/src/main/java/uk/gov/service/payments/logging/LoggingKeys.java
+++ b/logging/src/main/java/uk/gov/service/payments/logging/LoggingKeys.java
@@ -209,4 +209,8 @@ public interface LoggingKeys {
      */
     String STRIPE_EVENT_ID = "stripe_event_id";
 
+    /**
+     * The id of a dispute from gateway (Stripe specific)
+     */
+    String GATEWAY_DISPUTE_ID = "gateway_dispute_id";
 }


### PR DESCRIPTION
## WHAT
- Add gateway_dispute_id keys which is to be used for log lines about disputes.