### PR TITLE
PP-9142 Add AuthorisationMode enum

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/model/AuthorisationMode.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/AuthorisationMode.java
@@ -1,0 +1,31 @@
+package uk.gov.service.payments.commons.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.stream.Stream;
+
+public enum AuthorisationMode {
+    @JsonProperty("web")
+    WEB("web"),
+    @JsonProperty("moto_api")
+    MOTO_API("moto_api"),
+    @JsonProperty("external")
+    EXTERNAL("external");
+
+    private final String name;
+
+    AuthorisationMode(String name) {
+        this.name = name;
+    }
+
+    public static AuthorisationMode of(String name) {
+        return Stream.of(AuthorisationMode.values())
+                .filter(n -> n.getName().equals(name))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}


### PR DESCRIPTION
Enum will be used for specifying how payments will be authorised.
Current values are:

- "web": authorised by the user being directed to the `next_url` and filling out their payment details on the web page
- "moto_api": authorised by sending the card details directly for a MOTO payment using the new authorisation API
- "external": applies to payments that were added to Pay using the telephone payment notification API. These payments were authorised before details about them were sent to Pay.