### PR TITLE
PP-10173 Add ApiResponseInstantWithMicrosecondPrecisionSerializer

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/ApiResponseDateTimeSerializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/ApiResponseDateTimeSerializer.java
@@ -1,9 +1,7 @@
 package uk.gov.service.payments.commons.api.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
@@ -11,7 +9,6 @@ import java.time.ZonedDateTime;
 
 import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ApiResponseDateTimeSerializer extends StdSerializer<ZonedDateTime> {
 
     public ApiResponseDateTimeSerializer() {
@@ -26,4 +23,5 @@ public class ApiResponseDateTimeSerializer extends StdSerializer<ZonedDateTime> 
     public void serialize(ZonedDateTime value, JsonGenerator gen, SerializerProvider sp) throws IOException {
         gen.writeString(ISO_INSTANT_MILLISECOND_PRECISION.format(value));
     }
+
 }

--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/ApiResponseInstantWithMicrosecondPrecisionSerializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/ApiResponseInstantWithMicrosecondPrecisionSerializer.java
@@ -7,21 +7,21 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.time.Instant;
 
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MICROSECOND_PRECISION;
 
-public class ApiResponseInstantSerializer extends StdSerializer<Instant> {
+public class ApiResponseInstantWithMicrosecondPrecisionSerializer extends StdSerializer<Instant> {
 
-    public ApiResponseInstantSerializer() {
+    public ApiResponseInstantWithMicrosecondPrecisionSerializer() {
         this(null);
     }
 
-    private ApiResponseInstantSerializer(Class<Instant> t) {
+    private ApiResponseInstantWithMicrosecondPrecisionSerializer(Class<Instant> t) {
         super(t);
     }
 
     @Override
     public void serialize(Instant value, JsonGenerator gen, SerializerProvider sp) throws IOException {
-        gen.writeString(ISO_INSTANT_MILLISECOND_PRECISION.format(value));
+        gen.writeString(ISO_INSTANT_MICROSECOND_PRECISION.format(value));
     }
 
 }

--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/MicrosecondPrecisionDateTimeSerializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/MicrosecondPrecisionDateTimeSerializer.java
@@ -13,7 +13,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class MicrosecondPrecisionDateTimeSerializer extends StdSerializer<ZonedDateTime>  {
 
     public static final DateTimeFormatter MICROSECOND_FORMATTER =

--- a/model/src/main/java/uk/gov/service/payments/commons/model/ApiResponseDateTimeFormatter.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/ApiResponseDateTimeFormatter.java
@@ -1,5 +1,6 @@
 package uk.gov.service.payments.commons.model;
 
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
@@ -13,5 +14,19 @@ public class ApiResponseDateTimeFormatter {
      */
     public static final DateTimeFormatter ISO_INSTANT_MILLISECOND_PRECISION =
             new DateTimeFormatterBuilder().appendInstant(3).toFormatter(Locale.ENGLISH);
+
+    /**
+     * DateTimeFormatter that produces a standard ISO-8601 format date and time
+     * in UTC with microsecond precision (six fractional second digits, zero
+     * right-padded if necessary), for example 2015-10-21T07:28:00.000000Z
+     */
+    public static final DateTimeFormatter ISO_INSTANT_MICROSECOND_PRECISION =
+            new DateTimeFormatterBuilder().appendInstant(6).toFormatter(Locale.ENGLISH);
+
+    /**
+     * DateTimeFormatter that produces a standard ISO-8601 local date in UTC
+     * without an offset, for example 2022-10-04
+     */
+    public static final DateTimeFormatter ISO_LOCAL_DATE_IN_UTC = DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC);
 
 }

--- a/model/src/test/java/uk/gov/service/payments/commons/api/json/ApiResponseInstantWithMicrosecondPrecisionSerializerTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/api/json/ApiResponseInstantWithMicrosecondPrecisionSerializerTest.java
@@ -1,0 +1,35 @@
+package uk.gov.service.payments.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+class ApiResponseInstantWithMicrosecondPrecisionSerializerTest {
+
+    private final ApiResponseInstantWithMicrosecondPrecisionSerializer apiResponseInstantWithMicrosecondPrecisionSerializer =
+            new ApiResponseInstantWithMicrosecondPrecisionSerializer();
+
+    @Test
+    void shouldSerializeWithMicrosecondPrecision() throws IOException {
+        var instant = Instant.parse("2020-12-25T15:00:00.123456789Z");
+
+        var stringWriter = new StringWriter();
+        var jsonGenerator = new JsonFactory().createGenerator(stringWriter);
+
+        apiResponseInstantWithMicrosecondPrecisionSerializer.serialize(instant, jsonGenerator, new ObjectMapper().getSerializerProvider());
+        jsonGenerator.flush();
+
+        var expected = "\"2020-12-25T15:00:00.123456Z\"";
+        var actual = stringWriter.toString();
+
+        assertThat(actual, is(expected));
+    }
+
+}

--- a/model/src/test/java/uk/gov/service/payments/commons/model/ApiResponseDateTimeFormatterTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/model/ApiResponseDateTimeFormatterTest.java
@@ -3,21 +3,21 @@ package uk.gov.service.payments.commons.model;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import static java.time.Month.OCTOBER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.*;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MICROSECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_LOCAL_DATE_IN_UTC;
 
 class ApiResponseDateTimeFormatterTest {
 
     @Test
-    void shouldConvertInstantToIsoStringWithMillisecondPrecision() {
+    void isoInstantMillisecondPrecisionConvertsInstantToIsoStringWithMillisecondPrecision() {
         var instant = Instant.parse("2015-10-21T07:28:00.12356789Z");
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(instant);
@@ -26,18 +26,17 @@ class ApiResponseDateTimeFormatterTest {
     }
 
     @Test
-    void shouldConverInstantExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
+    void isoInstantMillisecondPrecisionConvertsInstantExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
         var instant = Instant.parse("2015-10-21T07:28:00Z");
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(instant);
 
         assertThat(result, is("2015-10-21T07:28:00.000Z"));
     }
-    
+
     @Test
-    void shouldConvertUtcZonedDateTimeToIsoStringWithMillisecondPrecision() {
-        var zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
-                LocalTime.of(7, 28, 0, 123456789), ZoneOffset.UTC);
+    void isoInstantMillisecondPrecisionConvertsUtcZonedDateTimeToIsoStringWithMillisecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2015-10-21T07:28:00.123456789"), ZoneOffset.UTC);
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
 
@@ -45,9 +44,9 @@ class ApiResponseDateTimeFormatterTest {
     }
 
     @Test
-    void shouldConvertNonUtcZonedDateTimeToIsoStringWithMillisecondPrecision() {
-        var zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
-                LocalTime.of(7, 28, 0, 123456789), ZoneId.of("America/Los_Angeles"));
+    void isoInstantMillisecondPrecisionConvertsNonUtcZonedDateTimeToIsoStringWithMillisecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2015-10-21T07:28:00.123456789"),
+                ZoneId.of("America/Los_Angeles"));
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
 
@@ -55,13 +54,103 @@ class ApiResponseDateTimeFormatterTest {
     }
 
     @Test
-    void shouldConvertZonedDateTimeExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
-        var zonedDateTime = ZonedDateTime.of(LocalDate.of(2015, OCTOBER, 21),
-                LocalTime.of(7, 28, 0), ZoneOffset.UTC);
+    void isoInstantMillisecondPrecisionConvertsZonedDateTimeExactlyOnTheSecondToIsoStringWithMillisecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2015-10-21T07:28:00"), ZoneOffset.UTC);
 
         String result = ISO_INSTANT_MILLISECOND_PRECISION.format(zonedDateTime);
 
         assertThat(result, is("2015-10-21T07:28:00.000Z"));
+    }
+
+    @Test
+    void isoInstantMicrosecondPrecisionConvertsInstantToIsoStringWithMicrosecondPrecision() {
+        var instant = Instant.parse("2015-10-21T07:28:00.12356789Z");
+
+        String result = ISO_INSTANT_MICROSECOND_PRECISION.format(instant);
+
+        assertThat(result, is("2015-10-21T07:28:00.123567Z"));
+    }
+
+    @Test
+    void isoInstantMicrosecondPrecisionConvertsInstantExactlyOnTheSecondToIsoStringWithMicrosecondPrecision() {
+        var instant = Instant.parse("2015-10-21T07:28:00Z");
+
+        String result = ISO_INSTANT_MICROSECOND_PRECISION.format(instant);
+
+        assertThat(result, is("2015-10-21T07:28:00.000000Z"));
+    }
+
+    @Test
+    void isoInstantMicrosecondPrecisionConvertsInstantExactlyOnTheMillisecondToIsoStringWithMicrosecondPrecision() {
+        var instant = Instant.parse("2015-10-21T07:28:00.123Z");
+
+        String result = ISO_INSTANT_MICROSECOND_PRECISION.format(instant);
+
+        assertThat(result, is("2015-10-21T07:28:00.123000Z"));
+    }
+
+    @Test
+    void isoInstantMicrosecondPrecisionConvertsUtcZonedDateTimeToIsoStringWithMicrosecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2015-10-21T07:28:00.123456789"), ZoneOffset.UTC);
+
+        String result = ISO_INSTANT_MICROSECOND_PRECISION.format(zonedDateTime);
+
+        assertThat(result, is("2015-10-21T07:28:00.123456Z"));
+    }
+
+    @Test
+    void isoInstantMicrosecondPrecisionConvertsNonUtcZonedDateTimeToIsoStringWithMicrosecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2015-10-21T07:28:00.123456789"),
+                ZoneId.of("America/Los_Angeles"));
+
+        String result = ISO_INSTANT_MICROSECOND_PRECISION.format(zonedDateTime);
+
+        assertThat(result, is("2015-10-21T14:28:00.123456Z"));
+    }
+
+    @Test
+    void isoInstantMicrosecondPrecisionConvertsZonedDateTimeExactlyOnTheSecondToIsoStringWithMicrosecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2015-10-21T07:28:00"), ZoneOffset.UTC);
+
+        String result = ISO_INSTANT_MICROSECOND_PRECISION.format(zonedDateTime);
+
+        assertThat(result, is("2015-10-21T07:28:00.000000Z"));
+    }
+
+    @Test
+    void isoInstantMicrosecondPrecisionConvertsZonedDateTimeExactlyOnTheMillisecondToIsoStringWithMicrosecondPrecision() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2015-10-21T07:28:00.123"), ZoneOffset.UTC);
+
+        String result = ISO_INSTANT_MICROSECOND_PRECISION.format(zonedDateTime);
+
+        assertThat(result, is("2015-10-21T07:28:00.123000Z"));
+    }
+
+    @Test
+    void isoLocalDateInUtcConvertsInstantToIsoLocalDateInUtc() {
+        var instant = Instant.parse("2022-10-04T12:34:56.789Z");
+
+        String result = ISO_LOCAL_DATE_IN_UTC.format(instant);
+
+        assertThat(result, is("2022-10-04"));
+    }
+
+    @Test
+    void isoLocalDateInUtcConvertsZonedDateTimeInUtcToIsoLocalDateInUtc() {
+        var zonedDateTime = ZonedDateTime.parse("2022-10-04T12:34:56.789Z");
+
+        String result = ISO_LOCAL_DATE_IN_UTC.format(zonedDateTime);
+
+        assertThat(result, is("2022-10-04"));
+    }
+
+    @Test
+    void isoLocalDateInUtcConvertsZonedDateTimeInAnotherTimeZoneWhereItIsAlreadyTomorrowToIsoLocalDateInUtc() {
+        var zonedDateTime = ZonedDateTime.of(LocalDateTime.parse("2022-10-05T06:07:08.123"), ZoneId.of("Pacific/Auckland"));
+
+        String result = ISO_LOCAL_DATE_IN_UTC.format(zonedDateTime);
+
+        assertThat(result, is("2022-10-04"));
     }
 
 }


### PR DESCRIPTION
Add `ApiResponseInstantWithMicrosecondPrecisionSerializer`, which is like `ApiResponseInstantSerializer` except that it uses microsecond precision rather than millisecond precision. It’s basically an equivalent of `MicrosecondPrecisionDateTimeSerializer` but for `Instant`s rather than `ZonedDateTime`s.

Also add `ISO_LOCAL_DATE_IN_UTC` to `ApiResponseDateTimeFormatter`, which is a direct copy of the same formatter in connector (and will eventually replace it).

Remove some `@JsonNaming` annotations from the serialisers because they’re not doing anything and we have equivalent annotations on the JSON classes themselves.