### PR TITLE
PP-10004 common testing harness ARM64 support

### DIFF
--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <docker-client.version>8.16.0</docker-client.version>
+        <jnr-ffi.version>2.2.12</jnr-ffi.version>
         <pact.version>3.6.15</pact.version>
         <hamcrest.version>2.2</hamcrest.version>
     </properties>
@@ -49,6 +50,11 @@
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
             <version>${docker-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-ffi</artifactId>
+            <version>2.2.12</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/testing/src/main/java/uk/gov/service/payments/commons/testing/db/PostgresDockerExtension.java
+++ b/testing/src/main/java/uk/gov/service/payments/commons/testing/db/PostgresDockerExtension.java
@@ -1,47 +1,14 @@
 package uk.gov.service.payments.commons.testing.db;
 
-import com.spotify.docker.client.exceptions.DockerCertificateException;
-import com.spotify.docker.client.exceptions.DockerException;
 import org.junit.jupiter.api.extension.Extension;
 
-import java.io.IOException;
-
-public class PostgresDockerExtension implements Extension {
-
-    private static PostgresContainer container;
-
+public class PostgresDockerExtension extends PostgresTestHelper implements Extension {
+    
     public PostgresDockerExtension() {
         startPostgresIfNecessary();
     }
-
-    public String getConnectionUrl() {
-        return container.getConnectionUrl();
-    }
-
-    private void startPostgresIfNecessary() {
-        try {
-            if (container == null) {
-                container = new PostgresContainer();
-            }
-        } catch (DockerCertificateException | InterruptedException | DockerException | IOException | ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public String getUsername() {
-        return container.getUsername();
-    }
-
-    public String getPassword() {
-        return container.getPassword();
-    }
-
-    public void stop() {
-        container.stop();
-        container = null;
-    }
-
-    public String getDriverClass() {
-        return "org.postgresql.Driver";
+   
+    public PostgresDockerExtension(String imageTage) {
+        startPostgresIfNecessary(imageTage);
     }
 }

--- a/testing/src/main/java/uk/gov/service/payments/commons/testing/db/PostgresDockerRule.java
+++ b/testing/src/main/java/uk/gov/service/payments/commons/testing/db/PostgresDockerRule.java
@@ -1,54 +1,21 @@
 package uk.gov.service.payments.commons.testing.db;
 
-import com.spotify.docker.client.exceptions.DockerCertificateException;
-import com.spotify.docker.client.exceptions.DockerException;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import java.io.IOException;
-
-public class PostgresDockerRule implements TestRule {
-
-    private static PostgresContainer container;
-
+public class PostgresDockerRule extends PostgresTestHelper implements TestRule {
+    
+    public PostgresDockerRule(String imageTag) {
+        startPostgresIfNecessary(imageTag);
+    }
+    
     public PostgresDockerRule() {
         startPostgresIfNecessary();
     }
-
-    public String getConnectionUrl() {
-        return container.getConnectionUrl();
-    }
-
+    
     @Override
     public Statement apply(Statement statement, Description description) {
         return statement;
-    }
-
-    private void startPostgresIfNecessary() {
-        try {
-            if (container == null) {
-                container = new PostgresContainer();
-            }
-        } catch (DockerCertificateException | InterruptedException | DockerException | IOException | ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public String getUsername() {
-        return container.getUsername();
-    }
-
-    public String getPassword() {
-        return container.getPassword();
-    }
-
-    public void stop() {
-        container.stop();
-        container = null;
-    }
-
-    public String getDriverClass() {
-        return "org.postgresql.Driver";
     }
 }

--- a/testing/src/main/java/uk/gov/service/payments/commons/testing/db/PostgresTestHelper.java
+++ b/testing/src/main/java/uk/gov/service/payments/commons/testing/db/PostgresTestHelper.java
@@ -1,0 +1,52 @@
+package uk.gov.service.payments.commons.testing.db;
+
+import com.spotify.docker.client.exceptions.DockerCertificateException;
+import com.spotify.docker.client.exceptions.DockerException;
+
+import java.io.IOException;
+
+public abstract class PostgresTestHelper {
+    
+    private static PostgresContainer container;
+    
+    static void startPostgresIfNecessary(String imageTag) {
+        try {
+            if (container == null) {
+                container = new PostgresContainer(imageTag);
+            }
+        } catch (DockerCertificateException | InterruptedException | DockerException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    static void startPostgresIfNecessary() {
+        try {
+            if (container == null) {
+                container = new PostgresContainer();
+            }
+        } catch (DockerCertificateException | InterruptedException | DockerException | IOException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public String getConnectionUrl() {
+        return container.getConnectionUrl();
+    }
+
+    public String getUsername() {
+        return container.getUsername();
+    }
+
+    public String getPassword() {
+        return container.getPassword();
+    }
+
+    public static void stop() {
+        container.stop();
+        container = null;
+    }
+
+    public String getDriverClass() {
+        return "org.postgresql.Driver";
+    }
+}


### PR DESCRIPTION
### WHAT

- package `jnr-ffi` dependency, this dependency enables access to native libraries outside of the JVM (in this case, the docker client on ARM64)
- added abstract helper class to DRY up the Postgres JUnit testing rules/extensions
- overloaded the PostgresContainer constructor to allow user specified image tag