### PR TITLE
PP-10116: Add detect-secrets workflow and update version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,14 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
+        
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/Yelp/detect-secrets
-  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  rev: v1.4.0
   hooks:
     - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
+      args: [ '--baseline', '.secrets.baseline' ]
       exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "version": "1.1.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -18,8 +21,14 @@
       "name": "CloudantDetector"
     },
     {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,13 +47,22 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -56,10 +74,6 @@
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -94,15 +108,6 @@
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
-        "is_verified": false,
-        "line_number": 3
-      }
-    ],
     "testing/src/test/resources/pact-from-broker.json": [
       {
         "type": "Hex High Entropy String",
@@ -122,5 +127,5 @@
       }
     ]
   },
-  "generated_at": "2021-08-13T15:57:11Z"
+  "generated_at": "2022-11-09T09:17:48Z"
 }


### PR DESCRIPTION
**WHAT**
	•	added a new github action to run detect-secrets
	•	updated the pre-commit config to update the detect-secrets hook to version 1.4
	•	rebaselined the repository's secrets baseline

Based on [alphagov/pay-webhooks#510](https://github.com/alphagov/pay-webhooks/pull/510)

**For reviewers**
	•	ensure your local version of detect-secrets matches the latest version in use on this branch
	•	run detect-secrets scan and ensure output matches the latest .secrets.baseline, the only change should be the generated timestamp