### PR TITLE
PP-10487 Allow delayed delivery of SQS messages

### DIFF
--- a/queue/src/main/java/uk/gov/service/payments/commons/queue/sqs/AbstractQueue.java
+++ b/queue/src/main/java/uk/gov/service/payments/commons/queue/sqs/AbstractQueue.java
@@ -26,6 +26,10 @@ public abstract class AbstractQueue {
         return sqsQueueService.sendMessage(queueUrl, message);
     }
 
+    public QueueMessage sendMessageToQueueWithDelay(String message, int delayInSeconds) throws QueueException {
+        return sqsQueueService.sendMessage(queueUrl, message, delayInSeconds);
+    }
+
     public List<QueueMessage> retrieveMessages() throws QueueException {
         return sqsQueueService
                 .receiveMessages(this.queueUrl, MESSAGE_ATTRIBUTES_TO_RECEIVE);

--- a/queue/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -42,6 +42,7 @@ public class SqsQueueService {
         SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody).withDelaySeconds(delayInSeconds);
         return sendMessage(sendMessageRequest);
     }
+    
     private QueueMessage sendMessage(SendMessageRequest sendMessageRequest) throws QueueException {
         try {
             SendMessageResult sendMessageResult = sqsClient.sendMessage(sendMessageRequest);

--- a/queue/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -53,6 +53,7 @@ public class SqsQueueService {
             throw new QueueException(e.getMessage());
         }
     }
+    
     public List<QueueMessage> receiveMessages(String queueUrl, String messageAttributeName) throws QueueException {
         try {
             ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);

--- a/queue/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
+++ b/queue/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
@@ -10,6 +10,7 @@ import com.amazonaws.services.sqs.model.AmazonSQSException;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import org.junit.Assert;
 import org.junit.Before;
@@ -62,7 +63,9 @@ public class SqsQueueServiceTest {
     public void shouldSendMessageToQueueSuccessfully() throws QueueException {
         SendMessageResult sendMessageResult = new SendMessageResult();
         sendMessageResult.setMessageId("test-message-id");
-        when(mockSqsClient.sendMessage(QUEUE_URL, MESSAGE)).thenReturn(sendMessageResult);
+        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE);
+        
+        when(mockSqsClient.sendMessage(sendMessageRequest)).thenReturn(sendMessageResult);
 
         QueueMessage message = sqsQueueService.sendMessage(QUEUE_URL, MESSAGE);
         assertEquals("test-message-id", message.getMessageId());
@@ -75,7 +78,8 @@ public class SqsQueueServiceTest {
 
     @Test(expected = QueueException.class)
     public void shouldThrowExceptionIfMessageIsNotSentToQueue() throws QueueException {
-        when(mockSqsClient.sendMessage(QUEUE_URL, MESSAGE)).thenThrow(AmazonSQSException.class);
+        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE);
+        when(mockSqsClient.sendMessage(sendMessageRequest)).thenThrow(AmazonSQSException.class);
 
         sqsQueueService.sendMessage(QUEUE_URL, MESSAGE);
     }


### PR DESCRIPTION
- Context: Occasional delays in database transations are causing an error whereby connector's task queue message handler picks up a new task before the associated database record has been updated
- Provided a method to add messages with a delivery delay, to allow sufficient time for the database to be updated before the message is handled
- Adjusted the associated unit test accordingly.