### PR TITLE
PP-10488 Rename logging key

### DIFF
--- a/logging/src/main/java/uk/gov/service/payments/logging/LoggingKeys.java
+++ b/logging/src/main/java/uk/gov/service/payments/logging/LoggingKeys.java
@@ -220,9 +220,9 @@ public interface LoggingKeys {
     String DISPUTE_EXTERNAL_ID = "dispute_external_id";
 
     /**
-     * Agreement external ID
+     * Agreement ID
      */
-    String AGREEMENT_EXTERNAL_ID = "agreement_external_id";
+    String AGREEMENT_ID = "agreement_id";
 
     /**
      * The authorisation mode for a payment


### PR DESCRIPTION
agreement_external_id -> agreement_id

We refer to this as the agreement_id everywhere in code, so change this to be consistent.