### PR TITLE
PP-10892: Only check for key expiry

### DIFF
--- a/.github/workflows/_check_gpg_signing_key.yml
+++ b/.github/workflows/_check_gpg_signing_key.yml
@@ -1,4 +1,4 @@
-name: Check GPG Signing Key Validity
+name: Check GPG Signing Key Expiration
 
 on:
   workflow_call:
@@ -13,12 +13,13 @@ jobs:
   check-signing-key:
     runs-on: ubuntu-latest
     steps:
-      - name: Check Signing Key Validity
+      - name: Check Signing Key Expiry
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: |
           echo
-          echo "Checking signing key for validity"
+          echo "Checking signing key for expiration"
+
           # See https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS for details of all the columns
           SECRET_KEY_DETAILS=$(gpg --with-colons --fixed-list-mode --show-keys <<<"$GPG_PRIVATE_KEY" | grep "^sec:")
           SECRET_KEY_VALIDITY=$(cut -f "2" -d ":" <<< "$SECRET_KEY_DETAILS")
@@ -30,29 +31,13 @@ jobs:
             SECRET_KEY_EXPIRATION_DATE=$(date -d "@${SECRET_KEY_EXPIRATION_TIMESTAMP}")
           fi
 
-          case "$SECRET_KEY_VALIDITY" in
-            f)
-              echo "Key is valid"
-              exit 0
-              ;;
-            e)
+          if [[ "$SECRET_KEY_VALIDITY" == "e" ]]; then
               echo "Key has expired!"
               echo
 
               echo "Key expired on $SECRET_KEY_EXPIRATION_DATE"
-              ;;
-            i)
-              echo "Key is invalid!"
-              ;;
-            *)
-              echo "Key is in an unknown state. Key details are:"
-              echo "$SECRET_KEY_DETAILS"
-              echo
-              echo "See https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS for key detail description"
-          esac
+              exit 1
+          fi
 
           echo
-          echo "Key cannot work for signing commits"
-          exit 1
-
-
+          echo "Key does not expire until $SECRET_KEY_EXPIRATION_DATE"


### PR DESCRIPTION
We aren't actively trusting the key, but the purpose of this test is only to check for expiry so changing the test to test for expiry _only_

I had the expiry check run in the unit tests workflow to test it now shows the key as not expired and you can see that successful run here: https://github.com/alphagov/pay-java-commons/actions/runs/4795620565/jobs/8530410304?pr=648

I made a simple docker file which use a repo that allows me to fake the time to test this:

```
 $ cat Dockerfile
FROM alpine:3.17

RUN apk add --no-cache --update \
  build-base \
  git \
  gnupg \
  vim

RUN git clone https://github.com/wolfcw/libfaketime.git
WORKDIR /libfaketime/src
RUN make install
WORKDIR /

COPY foo.key /foo.key

ENV LD_PRELOAD=/usr/local/lib/faketime/libfaketime.so.1
ENV FAKETIME_NO_CACHE=1

CMD gpg --with-colons --fixed-list-mode --show-keys < /foo.key
```

If you generate a key and test it with the above dockerfile you can change the faketime

```
docker build -t keytest .
docker run -e "FAKETIME=2024-01-01 00:00:00" --rm -ti keytest
docker run -e "FAKETIME=2030-01-01 00:00:00" --rm -ti keytest
```

You'll see the 2024 run will show a "-" on cert validity (since we haven't trusted it), but the 2030 run will show "e" for expired.

This proves that even if you aren't actively trusting the certificate the gpg command will show you it has expired.