### PR TITLE
PP-10892: Link to team manual from error and trigger release

### DIFF
--- a/.github/workflows/_check_gpg_signing_key.yml
+++ b/.github/workflows/_check_gpg_signing_key.yml
@@ -36,6 +36,8 @@ jobs:
               echo
 
               echo "Key expired on $SECRET_KEY_EXPIRATION_DATE"
+              echo
+              echo "See https://pay-team-manual.cloudapps.digital/manual/credential-management/rotate-maven-signing-key.html for help extending/rotating the key"
               exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ To include the utils module, add this to your project's pom.xml:
    <version>1.0.0-{version}</version>
  </dependency>
 ```
+


### PR DESCRIPTION
In the event that the signing key has expired link to the new team manual page with info about rotating the maven signing key.

Also a no-op change in the README to trigger a release on merge.