### PR TITLE
PP-10977 remove expired status from agreement

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/model/agreement/AgreementStatus.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/agreement/AgreementStatus.java
@@ -7,8 +7,7 @@ public enum AgreementStatus {
     CREATED,
     ACTIVE,
     INACTIVE,
-    CANCELLED,
-    EXPIRED;
+    CANCELLED;
 
     public static Optional<AgreementStatus> from(String agreementStatusName) {
         return Arrays.stream(AgreementStatus.values())


### PR DESCRIPTION
We don’t have any process/code that sets the payment_instrucment/agreement status to expired. Also, we don’t have any plans to set payment instruments to expired status.

- remove enum AgreementStatus.EXPIRED.