### PR TITLE
PP-11465-Create-CardExpiryDate-from-YearMonth

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/model/CardExpiryDate.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/CardExpiryDate.java
@@ -7,8 +7,9 @@ import java.util.regex.Pattern;
 public class CardExpiryDate {
 
     public static final Pattern CARD_EXPIRY_DATE_PATTERN = Pattern.compile("(0[1-9]|1[0-2])/([0-9]{2})");
-
     private static final String PREFIX_TO_MAKE_2_DIGIT_YEAR_INTO_4_DIGIT_YEAR = "20";
+    private static final YearMonth MIN_EXPIRY_DATE = YearMonth.of(2000, 1);
+    private static final YearMonth MAX_EXPIRY_DATE = YearMonth.of(2099, 12);
 
     private final String month2Digits;
     private final String year2Digits;
@@ -27,8 +28,11 @@ public class CardExpiryDate {
     }
     
     private CardExpiryDate(YearMonth expiryDate) {
+        if (expiryDate.isBefore(MIN_EXPIRY_DATE) || expiryDate.isAfter(MAX_EXPIRY_DATE)) {
+            throw new IllegalArgumentException("Expiry date must be in the range 01/2000 - 12/2099");
+        }
         int month = expiryDate.getMonthValue();
-        this.month2Digits = (month < 10) ? ("0" + month) : String.valueOf(month);
+        this.month2Digits = String.format("%02d", month);
         this.year2Digits = String.valueOf(expiryDate.getYear()).substring(2,4);
     }
     
@@ -45,9 +49,6 @@ public class CardExpiryDate {
     }
     
     public static CardExpiryDate valueOf(YearMonth expiryDate) {
-        if (expiryDate.getYear() < 2000 || expiryDate.getYear() > 2100) {
-            throw new IllegalArgumentException("Expiry date must be in the range 01/2000 - 12/2099");
-        }
         return new CardExpiryDate(expiryDate);
     }
     

--- a/model/src/main/java/uk/gov/service/payments/commons/model/CardExpiryDate.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/CardExpiryDate.java
@@ -45,6 +45,9 @@ public class CardExpiryDate {
     }
     
     public static CardExpiryDate valueOf(YearMonth expiryDate) {
+        if (expiryDate.getYear() < 2000 || expiryDate.getYear() > 2100) {
+            throw new IllegalArgumentException("Expiry date must be in the range 01/2000 - 12/2099");
+        }
         return new CardExpiryDate(expiryDate);
     }
     

--- a/model/src/main/java/uk/gov/service/payments/commons/model/CardExpiryDate.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/CardExpiryDate.java
@@ -25,7 +25,13 @@ public class CardExpiryDate {
         this.month2Digits = matcher.group(1);
         this.year2Digits = matcher.group(2);
     }
-
+    
+    private CardExpiryDate(YearMonth expiryDate) {
+        int month = expiryDate.getMonthValue();
+        this.month2Digits = (month < 10) ? ("0" + month) : String.valueOf(month);
+        this.year2Digits = String.valueOf(expiryDate.getYear()).substring(2,4);
+    }
+    
     /**
      * Parses a string in the MM/yy format used for expiry dates on most
      * payment cards into a CardExpiryDate. For example, "09/22".
@@ -37,7 +43,11 @@ public class CardExpiryDate {
     public static CardExpiryDate valueOf(String expiryDate) {
         return new CardExpiryDate(expiryDate);
     }
-
+    
+    public static CardExpiryDate valueOf(YearMonth expiryDate) {
+        return new CardExpiryDate(expiryDate);
+    }
+    
     public String getTwoDigitMonth() {
         return month2Digits;
     }

--- a/model/src/test/java/uk/gov/service/payments/commons/model/CardExpiryDateTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/model/CardExpiryDateTest.java
@@ -217,6 +217,22 @@ class CardExpiryDateTest {
     }
     
     @Test
+    void dateAfter2100ThrowsException() {
+        int expiryDateYear = 2123;
+        int expiryDateMonth = 11;
+        var yearMonth = YearMonth.of(expiryDateYear, expiryDateMonth);
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(yearMonth));
+    }
+
+    @Test
+    void dateBefore2000ThrowsException() {
+        int expiryDateYear = 1993;
+        int expiryDateMonth = 11;
+        var yearMonth = YearMonth.of(expiryDateYear, expiryDateMonth);
+        assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(yearMonth));
+    }
+    
+    @Test
     void month1WithNoLeadingZeroThrowsException() {
         var input = "1/22";
         assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(input));

--- a/model/src/test/java/uk/gov/service/payments/commons/model/CardExpiryDateTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/model/CardExpiryDateTest.java
@@ -189,7 +189,33 @@ class CardExpiryDateTest {
         assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2099, OCTOBER)));
         assertThat(cardExpiryDate.toString(), is("10/99"));
     }
+    
+    @Test
+    void createSuccessfullyFromYearMonthWithOneDigitMonth() {
+        int expiryDateYear = 2023;
+        int expiryDateMonth = 8;
+        var yearMonth = YearMonth.of(expiryDateYear, expiryDateMonth);
+        var cardExpiryDate = CardExpiryDate.valueOf(yearMonth);
+        assertThat(cardExpiryDate.getTwoDigitYear(), is("23"));
+        assertThat(cardExpiryDate.getFourDigitYear(), is("2023"));
+        assertThat(cardExpiryDate.getTwoDigitMonth(), is("08"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2023, AUGUST)));
+        assertThat(cardExpiryDate.toString(), is("08/23"));
+    }
 
+    @Test
+    void createSuccessfullyFromYearMonthWithTwoDigitMonth() {
+        int expiryDateYear = 2023;
+        int expiryDateMonth = 11;
+        var yearMonth = YearMonth.of(expiryDateYear, expiryDateMonth);
+        var cardExpiryDate = CardExpiryDate.valueOf(yearMonth);
+        assertThat(cardExpiryDate.getTwoDigitYear(), is("23"));
+        assertThat(cardExpiryDate.getFourDigitYear(), is("2023"));
+        assertThat(cardExpiryDate.getTwoDigitMonth(), is("11"));
+        assertThat(cardExpiryDate.toYearMonth(), is(YearMonth.of(2023, NOVEMBER)));
+        assertThat(cardExpiryDate.toString(), is("11/23"));
+    }
+    
     @Test
     void month1WithNoLeadingZeroThrowsException() {
         var input = "1/22";

--- a/model/src/test/java/uk/gov/service/payments/commons/model/CardExpiryDateTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/model/CardExpiryDateTest.java
@@ -218,16 +218,16 @@ class CardExpiryDateTest {
     
     @Test
     void dateAfter2100ThrowsException() {
-        int expiryDateYear = 2123;
-        int expiryDateMonth = 11;
+        int expiryDateYear = 2100;
+        int expiryDateMonth = 1;
         var yearMonth = YearMonth.of(expiryDateYear, expiryDateMonth);
         assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(yearMonth));
     }
 
     @Test
     void dateBefore2000ThrowsException() {
-        int expiryDateYear = 1993;
-        int expiryDateMonth = 11;
+        int expiryDateYear = 1999;
+        int expiryDateMonth = 12;
         var yearMonth = YearMonth.of(expiryDateYear, expiryDateMonth);
         assertThrows(IllegalArgumentException.class, () -> CardExpiryDate.valueOf(yearMonth));
     }


### PR DESCRIPTION
- Add valueOf and constructor to allow CardExpiryDate to be created from YearMonth
- This supports extraction of expiry date from Worldpay response to wallet authorisations