### PR TITLE
Pp11548/create custom pay metrics

### DIFF
--- a/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/Counter.java
+++ b/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/Counter.java
@@ -1,0 +1,42 @@
+package uk.gov.service.payments.commons.utils.prometheus;
+
+import org.apache.commons.lang3.ArrayUtils;
+
+public class Counter {
+    private final io.prometheus.client.Counter counter;
+    private final String[] defaultLabelValues;
+
+    public Counter(String name, String help, String ...labelNames) {
+        DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+
+        String[] allLabelNames = ArrayUtils.addAll(defaultLabelsSingleton.getLabelNames().toArray(new String[0]), labelNames);
+        this.defaultLabelValues = defaultLabelsSingleton.getLabelValues().toArray(new String[0]);
+
+        this.counter = io.prometheus.client.Counter.build()
+                .name(name)
+                .help(help)
+                .labelNames(allLabelNames)
+                .register();
+    }
+
+    public io.prometheus.client.Counter.Child labels(String ...labelValues) {
+        String[] allLabelValues = ArrayUtils.addAll(this.defaultLabelValues, labelValues);
+        return this.counter.labels(allLabelValues);
+    }
+
+    public void inc() {
+        if (this.defaultLabelValues.length == 0) {
+            this.counter.inc();
+        } else {
+            this.counter.labels(this.defaultLabelValues).inc();
+        }
+    }
+
+    public void inc(double amount) {
+        if (this.defaultLabelValues.length == 0) {
+            this.counter.inc(amount);
+        } else {
+            this.counter.labels(this.defaultLabelValues).inc(amount);
+        }
+    }
+}

--- a/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/DefaultLabelsSingleton.java
+++ b/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/DefaultLabelsSingleton.java
@@ -1,0 +1,39 @@
+package uk.gov.service.payments.commons.utils.prometheus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DefaultLabelsSingleton {
+    private static DefaultLabelsSingleton INSTANCE;
+    private final List<String> labelNames = new ArrayList<>();
+    private final List<String> labelValues = new ArrayList<>();
+
+    public static DefaultLabelsSingleton getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new DefaultLabelsSingleton();
+        }
+
+        return INSTANCE;
+    }
+
+    private DefaultLabelsSingleton() {
+    }
+
+    public List<String> getLabelNames() {
+        return this.labelNames;
+    }
+
+    public List<String> getLabelValues() {
+        return this.labelValues;
+    }
+
+    public void addLabel(String labelName, String labelValue) {
+        this.labelNames.add(labelName);
+        this.labelValues.add(labelValue);
+    }
+
+    public void clearLabels() {
+        this.labelNames.clear();
+        this.labelValues.clear();
+    }
+}

--- a/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/PayMetrics.java
+++ b/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/PayMetrics.java
@@ -1,0 +1,60 @@
+package uk.gov.service.payments.commons.utils.prometheus;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+
+public class PayMetrics {
+    private static final Logger logger = LoggerFactory.getLogger(PayMetrics.class);
+
+    public static io.prometheus.client.CollectorRegistry initialisePrometheusMetrics(com.codahale.metrics.MetricRegistry dropwizardMetricRegistry, URI ecsContainerMetadataUriV4) {
+        prometheusDefaultLabels(ecsContainerMetadataUriV4);
+        CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
+        collectorRegistry.register(new DropwizardExports(dropwizardMetricRegistry, new PrometheusDefaultLabelSampleBuilder()));
+        return collectorRegistry;
+    }
+
+    public static io.prometheus.client.CollectorRegistry initialisePrometheusMetrics(com.codahale.metrics.MetricRegistry dropwizardMetricRegistry) {
+        CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
+        collectorRegistry.register(new DropwizardExports(dropwizardMetricRegistry));
+        return collectorRegistry;
+    }
+
+    private static void prometheusDefaultLabels(URI ecsContainerMetadataUriV4) {
+        DefaultLabelsSingleton defaultLabels = DefaultLabelsSingleton.getInstance();
+
+        try {
+            logger.info("Getting container metadata from " + ecsContainerMetadataUriV4);
+
+            HttpRequest request = HttpRequest.newBuilder(ecsContainerMetadataUriV4).GET().build();
+            HttpClient httpClient = HttpClient.newHttpClient();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            logger.info("Status code from ECS: " + response.statusCode());
+
+            if (response.statusCode() == 200) {
+                var containerMetadata = new EcsContainerMetadataVersion4(response.body());
+
+                defaultLabels.addLabel("containerImageTag", containerMetadata.getContainerImageTag());
+                defaultLabels.addLabel("ecsClusterName", containerMetadata.getClusterName());
+                defaultLabels.addLabel("ecsServiceName", containerMetadata.getServiceName());
+                defaultLabels.addLabel("ecsTaskID", containerMetadata.getEcsTaskId());
+                defaultLabels.addLabel("awsAccountName", containerMetadata.getAccountName());
+
+                Optional<String> instanceIP = containerMetadata.getInstanceIP();
+                instanceIP.ifPresentOrElse(ip -> defaultLabels.addLabel("instance", ip),
+                        () -> logger.info("There was no IP for the container with ecsTaskID {} and ecsServiceName {}.",
+                                containerMetadata.getEcsTaskId(), containerMetadata.getServiceName()));
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/PrometheusDefaultLabelSampleBuilder.java
+++ b/utils/src/main/java/uk/gov/service/payments/commons/utils/prometheus/PrometheusDefaultLabelSampleBuilder.java
@@ -2,48 +2,18 @@ package uk.gov.service.payments.commons.utils.prometheus;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.dropwizard.samplebuilder.SampleBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 public class PrometheusDefaultLabelSampleBuilder implements SampleBuilder {
+    private final List<String> defaultLabelNames;
+    private final List<String> defaultLabelValues;
 
-    private static final Logger logger = LoggerFactory.getLogger(PrometheusDefaultLabelSampleBuilder.class);
-
-    private final Map<String, String> ecsLabels = new LinkedHashMap<>();
-
-    public PrometheusDefaultLabelSampleBuilder(URI ecsContainerMetadataUriV4) {
-        try {
-            logger.info("Getting container metadata from " + ecsContainerMetadataUriV4);
-            HttpRequest request = HttpRequest.newBuilder(ecsContainerMetadataUriV4).GET().build();
-            HttpClient httpClient = HttpClient.newHttpClient();
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            logger.info("Status code from ECS: " + response.statusCode());
-            if (response.statusCode() == 200) {
-                var containerMetadata = new EcsContainerMetadataVersion4(response.body());
-                ecsLabels.put("containerImageTag", containerMetadata.getContainerImageTag());
-                ecsLabels.put("ecsClusterName", containerMetadata.getClusterName());
-                ecsLabels.put("ecsServiceName", containerMetadata.getServiceName());
-                ecsLabels.put("ecsTaskID", containerMetadata.getEcsTaskId());
-                ecsLabels.put("awsAccountName", containerMetadata.getAccountName());
-                Optional<String> instanceIP = containerMetadata.getInstanceIP();
-                instanceIP.ifPresentOrElse(ip -> ecsLabels.put("instance", ip),
-                        () -> logger.info("There was no IP for the container with ecsTaskID {} and ecsServiceName {}.",
-                                containerMetadata.getEcsTaskId(), containerMetadata.getServiceName()));
-            }
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+    public PrometheusDefaultLabelSampleBuilder() {
+        DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+        this.defaultLabelNames = defaultLabelsSingleton.getLabelNames();
+        this.defaultLabelValues = defaultLabelsSingleton.getLabelValues();
     }
 
     @Override
@@ -56,8 +26,8 @@ public class PrometheusDefaultLabelSampleBuilder implements SampleBuilder {
         List<String> finalLabelNames = new ArrayList<>(additionalLabelNames);
         List<String> finalLabelValues = new ArrayList<>(additionalLabelValues);
 
-        finalLabelNames.addAll(ecsLabels.keySet());
-        finalLabelValues.addAll(ecsLabels.values());
+        finalLabelNames.addAll(defaultLabelNames);
+        finalLabelValues.addAll(defaultLabelValues);
 
         return new Collector.MetricFamilySamples.Sample(
                 Collector.sanitizeMetricName(dropwizardName + suffix),

--- a/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/CounterTest.java
+++ b/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/CounterTest.java
@@ -1,0 +1,116 @@
+package uk.gov.service.payments.commons.utils.prometheus;
+
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.prometheus.client.CollectorRegistry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.AfterEach;
+
+
+import java.util.Enumeration;
+import java.util.Optional;
+
+class CounterTest {
+    final CollectorRegistry defaultRegistry = CollectorRegistry.defaultRegistry;
+    final DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+
+    @AfterEach
+    void resetCollectorRegistryAndLabels() {
+        defaultRegistry.clear();
+        defaultLabelsSingleton.clearLabels();
+    }
+
+    @Test
+    void CreatingACounter_ShouldCreateACounterInTheDefaultRegistry() {
+        Counter counter = new Counter("test_counter", "Help Text for test_counter");
+
+        Optional<Collector.MetricFamilySamples> metricOption = getMetricFromDefaultRegistry("test_counter");
+
+        assertFalse(metricOption.isEmpty());
+
+        metricOption.ifPresent(
+                metric -> {
+                    assertEquals("Help Text for test_counter", metric.help);
+                }
+        );
+    }
+
+    @Test
+    void Counter_ShouldReturnChildCounterOnLabelsCall() {
+        Counter counter = new Counter("test_counter", "Help Text for test_counter");
+
+        assertInstanceOf(io.prometheus.client.Counter.Child.class, counter.labels());
+    }
+
+    @Test
+    void Counter_shouldBeIncrementableWithoutLabels() {
+        Counter counter = new Counter("test_counter_total", "Help text");
+        counter.inc();
+
+        double counterValue = this.defaultRegistry.getSampleValue("test_counter_total");
+        assertEquals(1.0, counterValue);
+
+        counter.inc(2.0);
+
+        counterValue = this.defaultRegistry.getSampleValue("test_counter_total");
+        assertEquals(3.0, counterValue);
+    }
+
+    @Test
+    void Counter_ShouldHaveDefaultLabels() {
+        defaultLabelsSingleton.addLabel("label1", "value1");
+        defaultLabelsSingleton.addLabel("label2", "value2");
+
+        Counter counter = new Counter("test_counter", "Help Text for test_counter");
+        counter.inc();
+
+        double sampleValue = this.defaultRegistry.getSampleValue("test_counter_total", new String[] {"label1", "label2"}, new String[] {"value1", "value2"});
+        assertEquals(1.0, sampleValue);
+    }
+
+    @Test
+    void Counter_ShouldHaveNamedLabelsWithoutDefaultWhenNoDefault() {
+        Counter counter = new Counter("test_counter", "Help Text for test_counter", "label1", "label2");
+        counter.labels("value1", "value2").inc();
+
+        double sampleValue = this.defaultRegistry.getSampleValue("test_counter_total", new String[] {"label1", "label2"}, new String[] {"value1", "value2"});
+        assertEquals(1.0, sampleValue);
+    }
+
+    @Test
+    void Counter_ShouldHaveDefaultAndNamedLabels() {
+        defaultLabelsSingleton.addLabel("defaultLabel1", "defaultValue1");
+        defaultLabelsSingleton.addLabel("defaultLabel2", "defaultValue2");
+
+        Counter counter = new Counter("test_counter", "Help Text for test_counter", "customLabel1", "customLabel2");
+        counter.labels("customValue1", "customValue2").inc();
+
+        double sampleValue = this.defaultRegistry.getSampleValue("test_counter_total", new String[] {"defaultLabel1", "defaultLabel2", "customLabel1", "customLabel2"}, new String[] {"defaultValue1", "defaultValue2", "customValue1", "customValue2"});
+        assertEquals(1.0, sampleValue);
+
+
+        counter.labels("customValue1", "customValue2").inc(2.0);
+
+        sampleValue = this.defaultRegistry.getSampleValue("test_counter_total", new String[] {"defaultLabel1", "defaultLabel2", "customLabel1", "customLabel2"}, new String[] {"defaultValue1", "defaultValue2", "customValue1", "customValue2"});
+        assertEquals(3.0, sampleValue);
+    }
+
+
+    private Optional<Collector.MetricFamilySamples> getMetricFromDefaultRegistry(String name) {
+        for (Enumeration<Collector.MetricFamilySamples> enumerator = this.defaultRegistry.metricFamilySamples(); enumerator.hasMoreElements();) {
+            Collector.MetricFamilySamples familySamples = enumerator.nextElement();
+            if (familySamples.name.equals(name)) {
+                return Optional.of(familySamples);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/DefaultLabelsSingletonTest.java
+++ b/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/DefaultLabelsSingletonTest.java
@@ -1,0 +1,45 @@
+package uk.gov.service.payments.commons.utils.prometheus;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class DefaultLabelsSingletonTest {
+    @Test
+    void CreatingEmptyLabelSet() {
+        DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+
+        assertTrue(defaultLabelsSingleton.getLabelNames().isEmpty());
+        assertTrue(defaultLabelsSingleton.getLabelValues().isEmpty());
+    }
+
+    @Test
+    void AddingLabels() {
+        DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+
+        defaultLabelsSingleton.addLabel("Name", "Value");
+        defaultLabelsSingleton.addLabel("Foo", "Bar");
+
+        String[] expectedLabelNames = new String[] {"Name", "Foo"};
+        String[] actualLabelNames = defaultLabelsSingleton.getLabelNames().toArray(new String[0]);
+        assertArrayEquals(actualLabelNames, expectedLabelNames);
+
+        String[] expectedLabelValues = new String[] {"Value", "Bar"};
+        String[] actualLabelValues = defaultLabelsSingleton.getLabelValues().toArray(new String[0]);
+        assertArrayEquals(actualLabelValues, expectedLabelValues);
+    }
+
+    @Test
+    void ClearingLabels() {
+        DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+
+        defaultLabelsSingleton.addLabel("Name", "Value");
+        defaultLabelsSingleton.addLabel("Foo", "Bar");
+
+        defaultLabelsSingleton.clearLabels();
+
+        assertTrue(defaultLabelsSingleton.getLabelNames().isEmpty());
+        assertTrue(defaultLabelsSingleton.getLabelValues().isEmpty());
+    }
+}

--- a/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/PayMetricsTest.java
+++ b/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/PayMetricsTest.java
@@ -1,0 +1,52 @@
+package uk.gov.service.payments.commons.utils.prometheus;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+@WireMockTest(httpPort = 8080)
+class PayMetricsTest {
+    final DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+    final CollectorRegistry collectorRegistry = CollectorRegistry.defaultRegistry;
+    final MetricRegistry dropWizardMetricsRegistry = new MetricRegistry();
+
+    @AfterEach
+    void resetCollectorRegistryAndDefaultLabels() {
+        defaultLabelsSingleton.clearLabels();
+        collectorRegistry.clear();
+    }
+
+    @Test
+    void initialisePrometheusMetricsWithoutMetadataUri_ShouldCreateNoDefaultLabels() {
+        PayMetrics.initialisePrometheusMetrics(dropWizardMetricsRegistry);
+
+        assertThat(defaultLabelsSingleton.getLabelNames(), empty());
+        assertThat(defaultLabelsSingleton.getLabelValues(), empty());
+    }
+
+    @Test
+    void initialisePrometheusMetricsWithMetadataUri_ShouldCreateECSDefaultLabels() throws Exception {
+        String containerMetadata = new String(getClass().getClassLoader().getResourceAsStream("ecs-container-metadata.json").readAllBytes());
+        stubFor(get("/v4/b322172c022b4a8c9411f923350cb623-1121955312").willReturn(okJson(containerMetadata)));
+
+        PayMetrics.initialisePrometheusMetrics(dropWizardMetricsRegistry, new URI("http://localhost:8080/v4/b322172c022b4a8c9411f923350cb623-1121955312"));
+
+        var values = new EcsContainerMetadataVersion4(containerMetadata);
+
+        assertThat(defaultLabelsSingleton.getLabelNames(), contains("containerImageTag", "ecsClusterName", "ecsServiceName", "ecsTaskID", "awsAccountName", "instance"));
+        assertThat(defaultLabelsSingleton.getLabelValues(), contains(
+                values.getContainerImageTag(), values.getClusterName(), values.getServiceName(), values.getEcsTaskId(), values.getAccountName(), values.getInstanceIP().get())
+        );
+    }
+}

--- a/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/PrometheusDefaultLabelSampleBuilderTest.java
+++ b/utils/src/test/java/uk/gov/service/payments/commons/utils/prometheus/PrometheusDefaultLabelSampleBuilderTest.java
@@ -1,36 +1,35 @@
 package uk.gov.service.payments.commons.utils.prometheus;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 
-@WireMockTest(httpPort = 8080)
 class PrometheusDefaultLabelSampleBuilderTest {
+
+    DefaultLabelsSingleton defaultLabelsSingleton = DefaultLabelsSingleton.getInstance();
+
+    @AfterEach
+    void resetLabels() {
+        defaultLabelsSingleton.clearLabels();
+    }
     
     @Test
     void testSampleLabels() throws Exception {
-        String containerMetadata = new String(getClass().getClassLoader().getResourceAsStream("ecs-container-metadata.json").readAllBytes());
-        stubFor(get("/v4/b322172c022b4a8c9411f923350cb623-1121955312").willReturn(okJson(containerMetadata)));
+        defaultLabelsSingleton.addLabel("defaultLabel1", "defaultValue1");
+        defaultLabelsSingleton.addLabel("defaultLabel2", "defaultValue2");
 
         List<String> additionalLabelNames = Arrays.asList("name1", "name2", "name3");
         List<String> additionalLabelValues = Arrays.asList("value1", "value2", "value3");
 
-        var prometheusDefaultLabelSampleBuilder = new PrometheusDefaultLabelSampleBuilder(new URI("http://localhost:8080/v4/b322172c022b4a8c9411f923350cb623-1121955312"));
-        var sample = prometheusDefaultLabelSampleBuilder.createSample("a-metric", null, additionalLabelNames, additionalLabelValues, 1.0);
-        assertThat(sample.labelNames, contains("name1", "name2", "name3", "containerImageTag", "ecsClusterName", "ecsServiceName", "ecsTaskID", "awsAccountName", "instance"));
-        var values = new EcsContainerMetadataVersion4(containerMetadata);
-        assertThat(sample.labelValues, contains("value1", "value2", "value3", values.getContainerImageTag(), values.getClusterName(),
-                values.getServiceName(), values.getEcsTaskId(), values.getAccountName(), values.getInstanceIP().get()));
+        var prometheusDefaultLabelSampleBuilder = new PrometheusDefaultLabelSampleBuilder();
 
+        var sample = prometheusDefaultLabelSampleBuilder.createSample("a-metric", null, additionalLabelNames, additionalLabelValues, 1.0);
+        assertThat(sample.labelNames, contains("name1", "name2", "name3", "defaultLabel1", "defaultLabel2"));
+        assertThat(sample.labelValues, contains("value1", "value2", "value3", "defaultValue1", "defaultValue2"));
     }
 }


### PR DESCRIPTION
The default java client prometheus library cannot add default metrics to metrics. The DropWizardExports class allows adding default labels by providing a custom metric sample builder (which was our previous approach) but these do not apply to first class prometheus metrics.

This PR adds:
1. A DefaultLabelsSingleton class which can be populated at app initialisation time and used to populate the default labels and values by all metrics
2. A PayMetrics class with 2 static methods to initialise the prometheus collector registry, and the default labels singleton
3. A Counter Class to act as an abstraction to the prometheus counter classes. This is designed to have our own creation which creates a prometheus Counter in the default registry with the default labels if they have been defined. It also provides a proxy to the native inc methods where the counter is created with no custom labels.
4. Refactors the prometheus sample builder to use the default labels singleton and not query ECS directly.

We also need at least a gauge and histogram abstractions classes but this is enough code in 1 go, and in a language I don't know well, so I thought it best to get this reviewed before I create the other abstractions.