### PR TITLE
PP-11548: Fix release name in createRelease step

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -56,7 +56,7 @@ jobs:
             const releaseResponse = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: "Release $PACKAGE_VERSION",
+              name: "Release ${{ steps.set-package-version.outputs.PACKAGE_VERSION }}",
               tag_name: "${{ steps.set-package-version.outputs.PACKAGE_VERSION }}",
               generate_release_notes: true,
             })


### PR DESCRIPTION
Minor oops. The first release created by this workflow had the literal name `Release $PACKAGE_VERSION`.

This change uses the correct github output instead of assuming it's in the env.