### PR TITLE
PP-11138: Github Actions security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay


### PR DESCRIPTION
Set Dependabot config for Github Actions to receive security updates only.