### PR TITLE
PP12302 Add method to find free port without collisions

### DIFF
--- a/testing/src/main/java/uk/gov/service/payments/commons/testing/port/PortFactory.java
+++ b/testing/src/main/java/uk/gov/service/payments/commons/testing/port/PortFactory.java
@@ -17,4 +17,18 @@ public class PortFactory {
         }
         return port;
     }
+
+    public static int findFreePortWithoutCollision(int... existingPorts) {
+        boolean collision = true;
+        int port = 0;
+
+        while (collision) {
+            port = findFreePort();
+            collision = false;
+            for (int existingPort : existingPorts) {
+                collision = collision || port == existingPort;
+            }
+        }
+        return port;
+    }
 }


### PR DESCRIPTION
### WHAT YOU DID
Add method to PortFactory to find a free port that does not conflict with a list of provided ports
This allows for finding multiple free ports in one go, rather than having to use a free port before finding the next