### PR TITLE
PP-12520 Ignore some Maven dependency versions in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,39 @@
+--
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "03:00"
-  open-pull-requests-limit: 10
-  labels:
-  - dependencies
-  - govuk-pay
-  - java
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 0
-  labels:
-  - dependencies
-  - govuk-pay
-  - github_actions
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "03:00"
+    ignore:
+      - dependency-name: "org.hibernate:hibernate-validator"
+        # Dropwizard 2.x and 3.x use Hibernate Validator 6
+        versions:
+          - ">= 7"
+      - dependency-name: "org.dhatim:dropwizard-sentry"
+        # We essentially forked Dropwizard Sentry because it did not support
+        # Dropwizard 3.x — there is now a Dropwizard Sentry 4.x, which supports
+        # Dropwizard 4.x (and maybe Dropwizard 3.x), but we’d need to do work
+        # to go back to using an unmodified version
+        versions:
+          - ">= 4"
+      - dependency-name: "org.eclipse.persistence:org.eclipse.persistence.jpa"
+        # We use EclipseLink 2.7.x in our Java microservices
+        versions:
+          - ">= 3"
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - govuk-pay
+      - java
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - govuk-pay
+      - github_actions


### PR DESCRIPTION
Ignore some versions of Maven dependencies we cannot upgrade to in Dependabot configuration.

Also fix problems reported by `yamllint`.