### PR TITLE
PP-12520 Change two dashes to three to fix Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
---
+---
 version: 2
 updates:
   - package-ecosystem: maven


### PR DESCRIPTION
Just two dashes actually makes the file invalid YAML and stops it from being parsed.