### PR TITLE
PP-12831: Update Maven server-id to central

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_CENTRAL_USERNAME # env variable for username in deploy
           server-password: MAVEN_CENTRAL_TOKEN # pragma: allowlist secret  - env variable for token in deploy
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
                 <version>1.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
+                    <serverId>central</serverId>
                     <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
@@ -253,7 +253,7 @@
 
     <distributionManagement>
         <repository>
-            <id>ossrh</id>
+            <id>central</id>
             <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>


### PR DESCRIPTION
Our previous attempt at deploying gave the following error: 

```
Server credentials with ID "ossrh" not found! 
```

It's not clear whether the old server-id has been deprecated in favour of `central` - let's try this out.