### PR TITLE
bau: Move AllowedString constraint to pay-java-commons

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/AllowedStrings.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/AllowedStrings.java
@@ -1,0 +1,33 @@
+package uk.gov.service.payments.commons.api.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ FIELD })
+@Retention(RUNTIME)
+@Constraint(validatedBy = AllowedStringsValidator.class)
+@Documented
+public @interface AllowedStrings {
+
+    String message();
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+    
+    String[] allowed();
+
+    @Target({ FIELD })
+    @Retention(RUNTIME)
+    @Documented
+    @interface List {
+
+        AllowedStrings[] value();
+    }
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/api/validation/AllowedStringsValidator.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/validation/AllowedStringsValidator.java
@@ -1,0 +1,21 @@
+package uk.gov.service.payments.commons.api.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class AllowedStringsValidator implements ConstraintValidator<AllowedStrings, String>  {
+
+    private Set<String> allowedStrings;
+    
+    @Override
+    public void initialize(AllowedStrings parameters) {
+        allowedStrings = Set.of(parameters.allowed());
+    }
+    
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return false;
+        return allowedStrings.contains(value);
+    }
+}


### PR DESCRIPTION
Moving from [pay-connector](https://github.com/alphagov/pay-connector/blob/master/src/main/java/uk/gov/pay/connector/util/validation/AllowedStrings.java) as this validator would be useful for other java projects.