### PR TITLE
PP-13220 Better consistency for Instant serialisers/deserialisers

### DIFF
--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/ApiResponseDateTimeSerializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/ApiResponseDateTimeSerializer.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class ApiResponseDateTimeSerializer extends StdSerializer<ZonedDateTime> {
 

--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondDeserializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondDeserializer.java
@@ -1,0 +1,27 @@
+package uk.gov.service.payments.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MICROSECOND_PRECISION;
+
+public class IsoInstantMicrosecondDeserializer extends StdDeserializer<Instant> {
+
+    public IsoInstantMicrosecondDeserializer() {
+        this(null);
+    }
+
+    private IsoInstantMicrosecondDeserializer(Class<Instant> t) {
+        super(t);
+    }
+
+    @Override
+    public Instant deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+       return ISO_INSTANT_MICROSECOND_PRECISION.parse(jsonParser.getText(), Instant::from);
+    }
+
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondSerializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondSerializer.java
@@ -7,15 +7,15 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.time.Instant;
 
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MICROSECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MICROSECOND_PRECISION;
 
-public class ApiResponseInstantWithMicrosecondPrecisionSerializer extends StdSerializer<Instant> {
+public class IsoInstantMicrosecondSerializer extends StdSerializer<Instant> {
 
-    public ApiResponseInstantWithMicrosecondPrecisionSerializer() {
+    public IsoInstantMicrosecondSerializer() {
         this(null);
     }
 
-    private ApiResponseInstantWithMicrosecondPrecisionSerializer(Class<Instant> t) {
+    private IsoInstantMicrosecondSerializer(Class<Instant> t) {
         super(t);
     }
 

--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondDeserializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondDeserializer.java
@@ -1,0 +1,27 @@
+package uk.gov.service.payments.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
+
+public class IsoInstantMillisecondDeserializer extends StdDeserializer<Instant> {
+
+    public IsoInstantMillisecondDeserializer() {
+        this(null);
+    }
+
+    private IsoInstantMillisecondDeserializer(Class<Instant> t) {
+        super(t);
+    }
+
+    @Override
+    public Instant deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+       return ISO_INSTANT_MILLISECOND_PRECISION.parse(jsonParser.getText(), Instant::from);
+    }
+
+}

--- a/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondSerializer.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondSerializer.java
@@ -7,15 +7,15 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import java.io.IOException;
 import java.time.Instant;
 
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
 
-public class ApiResponseInstantSerializer extends StdSerializer<Instant> {
+public class IsoInstantMillisecondSerializer extends StdSerializer<Instant> {
 
-    public ApiResponseInstantSerializer() {
+    public IsoInstantMillisecondSerializer() {
         this(null);
     }
 
-    private ApiResponseInstantSerializer(Class<Instant> t) {
+    private IsoInstantMillisecondSerializer(Class<Instant> t) {
         super(t);
     }
 

--- a/model/src/main/java/uk/gov/service/payments/commons/model/CommonDateTimeFormatters.java
+++ b/model/src/main/java/uk/gov/service/payments/commons/model/CommonDateTimeFormatters.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Locale;
 
-public class ApiResponseDateTimeFormatter {
+public class CommonDateTimeFormatters {
 
     /**
      * DateTimeFormatter that produces a standard ISO-8601 format date and time
@@ -27,6 +27,7 @@ public class ApiResponseDateTimeFormatter {
      * DateTimeFormatter that produces a standard ISO-8601 local date in UTC
      * without an offset, for example 2022-10-04
      */
-    public static final DateTimeFormatter ISO_LOCAL_DATE_IN_UTC = DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC);
+    public static final DateTimeFormatter ISO_LOCAL_DATE_IN_UTC =
+            DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC);
 
 }

--- a/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondDeserializerTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondDeserializerTest.java
@@ -1,0 +1,128 @@
+package uk.gov.service.payments.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IsoInstantMicrosecondDeserializerTest {
+
+    private record JsonObjectWithInstant(
+            @JsonDeserialize(using = IsoInstantMicrosecondDeserializer.class) Instant instant) { }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldDeserializeIsoInstantStringWithSecondsWith6DecimalPlacesToInstant() throws JsonProcessingException {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.123456Z"
+                }
+                """;
+
+        JsonObjectWithInstant deserializedJsonObject = objectMapper.readValue(jsonString, JsonObjectWithInstant.class);
+
+        assertThat(deserializedJsonObject.instant(), is(Instant.parse("2024-10-02T09:30:00.123456Z")));
+    }
+
+    @Test
+    void shouldDeserializeIsoInstantStringWithSecondsWith6DecimalPlacesOfZeroToInstant() throws JsonProcessingException {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.000000Z"
+                }
+                """;
+
+        JsonObjectWithInstant deserializedJsonObject = objectMapper.readValue(jsonString, JsonObjectWithInstant.class);
+
+        assertThat(deserializedJsonObject.instant(), is(Instant.parse("2024-10-02T09:30:00.000Z")));
+    }
+
+    @Test
+    void shouldDeserializeNullToNull() throws JsonProcessingException {
+        var jsonString = """
+                {
+                  "instant": null
+                }
+                """;
+
+        JsonObjectWithInstant deserializedJsonObject = objectMapper.readValue(jsonString, JsonObjectWithInstant.class);
+
+        assertThat(deserializedJsonObject.instant(), is(nullValue()));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith5DecimalPlaces() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.12345Z"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith7DecimalPlaces() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.1234567Z"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith3DecimalPlaces() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.123Z"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith6DecimalPlacesButNoTrailingZ() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.123456"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeNonsenseString() {
+        var jsonString = """
+                {
+                  "instant": "This is clearly not an ISO instant"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeNonString() {
+        var jsonString = """
+                {
+                  "instant": 1727861400123456
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+}

--- a/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondSerializerTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMicrosecondSerializerTest.java
@@ -11,10 +11,9 @@ import java.time.Instant;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-class ApiResponseInstantWithMicrosecondPrecisionSerializerTest {
+class IsoInstantMicrosecondSerializerTest {
 
-    private final ApiResponseInstantWithMicrosecondPrecisionSerializer apiResponseInstantWithMicrosecondPrecisionSerializer =
-            new ApiResponseInstantWithMicrosecondPrecisionSerializer();
+    private final IsoInstantMicrosecondSerializer isoInstantMicrosecondSerializer = new IsoInstantMicrosecondSerializer();
 
     @Test
     void shouldSerializeWithMicrosecondPrecision() throws IOException {
@@ -23,7 +22,7 @@ class ApiResponseInstantWithMicrosecondPrecisionSerializerTest {
         var stringWriter = new StringWriter();
         var jsonGenerator = new JsonFactory().createGenerator(stringWriter);
 
-        apiResponseInstantWithMicrosecondPrecisionSerializer.serialize(instant, jsonGenerator, new ObjectMapper().getSerializerProvider());
+        isoInstantMicrosecondSerializer.serialize(instant, jsonGenerator, new ObjectMapper().getSerializerProvider());
         jsonGenerator.flush();
 
         var expected = "\"2020-12-25T15:00:00.123456Z\"";

--- a/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondDeserializerTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondDeserializerTest.java
@@ -1,0 +1,128 @@
+package uk.gov.service.payments.commons.api.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class IsoInstantMillisecondDeserializerTest {
+
+    private record JsonObjectWithInstant(
+            @JsonDeserialize(using = IsoInstantMillisecondDeserializer.class) Instant instant) { }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void shouldDeserializeIsoInstantStringWithSecondsWith3DecimalPlacesToInstant() throws JsonProcessingException {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.123Z"
+                }
+                """;
+
+        JsonObjectWithInstant deserializedJsonObject = objectMapper.readValue(jsonString, JsonObjectWithInstant.class);
+
+        assertThat(deserializedJsonObject.instant(), is(Instant.parse("2024-10-02T09:30:00.123Z")));
+    }
+
+    @Test
+    void shouldDeserializeIsoInstantStringWithSecondsWith3DecimalPlacesOfZeroToInstant() throws JsonProcessingException {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.000Z"
+                }
+                """;
+
+        JsonObjectWithInstant deserializedJsonObject = objectMapper.readValue(jsonString, JsonObjectWithInstant.class);
+
+        assertThat(deserializedJsonObject.instant(), is(Instant.parse("2024-10-02T09:30:00.000Z")));
+    }
+
+    @Test
+    void shouldDeserializeNullToNull() throws JsonProcessingException {
+        var jsonString = """
+                {
+                  "instant": null
+                }
+                """;
+
+        JsonObjectWithInstant deserializedJsonObject = objectMapper.readValue(jsonString, JsonObjectWithInstant.class);
+
+        assertThat(deserializedJsonObject.instant(), is(nullValue()));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith2DecimalPlaces() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.12Z"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith4DecimalPlaces() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.1234Z"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith6DecimalPlaces() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.123456Z"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeIsoStringWith6DecimalPlacesButNoTrailingZ() {
+        var jsonString = """
+                {
+                  "instant": "2024-10-02T09:30:00.123"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeNonsenseString() {
+        var jsonString = """
+                {
+                  "instant": "This is clearly not an ISO instant"
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTryingToDeserializeNonString() {
+        var jsonString = """
+                {
+                  "instant": 1727861400123
+                }
+                """;
+
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue(jsonString, JsonObjectWithInstant.class));
+    }
+
+}

--- a/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondSerializerTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/api/json/IsoInstantMillisecondSerializerTest.java
@@ -11,9 +11,9 @@ import java.time.Instant;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-class ApiResponseInstantSerializerTest {
+class IsoInstantMillisecondSerializerTest {
 
-    private final ApiResponseInstantSerializer apiResponseInstantSerializer = new ApiResponseInstantSerializer();
+    private final IsoInstantMillisecondSerializer isoInstantMillisecondSerializer = new IsoInstantMillisecondSerializer();
 
     @Test
     void shouldSerializeWithMillisecondPrecision() throws IOException {
@@ -22,7 +22,7 @@ class ApiResponseInstantSerializerTest {
         var stringWriter = new StringWriter();
         var jsonGenerator = new JsonFactory().createGenerator(stringWriter);
 
-        apiResponseInstantSerializer.serialize(instant, jsonGenerator, new ObjectMapper().getSerializerProvider());
+        isoInstantMillisecondSerializer.serialize(instant, jsonGenerator, new ObjectMapper().getSerializerProvider());
         jsonGenerator.flush();
 
         var expected = "\"2020-12-25T15:00:00.123Z\"";

--- a/model/src/test/java/uk/gov/service/payments/commons/model/CommonDateTimeFormattersTest.java
+++ b/model/src/test/java/uk/gov/service/payments/commons/model/CommonDateTimeFormattersTest.java
@@ -10,11 +10,11 @@ import java.time.ZonedDateTime;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MICROSECOND_PRECISION;
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
-import static uk.gov.service.payments.commons.model.ApiResponseDateTimeFormatter.ISO_LOCAL_DATE_IN_UTC;
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MICROSECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.service.payments.commons.model.CommonDateTimeFormatters.ISO_LOCAL_DATE_IN_UTC;
 
-class ApiResponseDateTimeFormatterTest {
+class CommonDateTimeFormattersTest {
 
     @Test
     void isoInstantMillisecondPrecisionConvertsInstantToIsoStringWithMillisecondPrecision() {


### PR DESCRIPTION
- Rename `ApiResponseDateTimeFormatter` to `CommonDateTimeFormatters` since it’s not just used for API responses
- Rename `ApiResponseInstantSerializer` to `IsoInstantMillisecondSerializer` because it’s not just used for API responses and to reflect it has millisecond precision
- Rename `ApiResponseInstantWithMicrosecondPrecisionSerializer` to `IsoInstantMicrosecondSerializer` because it’s not just used for API responses
- Add `IsoInstantMillisecondDeserializer` and `IsoInstantMicrosecondDeserializer` — these parse ISO instant strings into `Instant` objects and are strict about how any decimal places are required for the seconds (three for millisecond and six for microsecond)