### PR TITLE
BAU: Add missing Licence and Vulnerability Disclosure to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ To include the utils module, add this to your project's pom.xml:
  </dependency>
 ```
 
+## Licence
+
+[MIT License](https://github.com/alphagov/pay-java-commons/blob/master/LICENSE)
+
+## Vulnerability Disclosure
+
+GOV.UK Pay aims to stay secure for everyone.
+If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner.
+Please refer to our [vulnerability disclosure policy](https://www.gov.uk/help/report-vulnerability) and our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file for details.


### PR DESCRIPTION
Adds missing sections to the repo README.

Text based on the [pay-frontend README](https://github.com/alphagov/pay-frontend?tab=readme-ov-file#licence).