### PR TITLE
PP-13575 Investigate java AWS SDK v2 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>validation</module>
         <module>logging-dropwizard-3</module>
         <module>queue</module>
+        <module>queue-java-aws-sdk-v2</module>
     </modules>
 
     <dependencyManagement>

--- a/queue-java-aws-sdk-v2/pom.xml
+++ b/queue-java-aws-sdk-v2/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>pay-java-commons</artifactId>
+        <groupId>uk.gov.service.payments</groupId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>queue-java-aws-sdk-v2</artifactId>
+    <name>Classes for receiving and sending queue messages</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <!-- Main dependencies that are imported from one of the BOMs specified
+             in <dependencyManagement> in the parent POM, so no explicit versions needed -->
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
+
+        <!-- Main dependencies that need explicit versions -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+            <version>2.30.13</version>
+        </dependency>
+
+        <!-- Test dependencies that are imported from one of the BOMs specified
+             in <dependencyManagement> in the parent POM, so no explicit versions needed -->
+
+        <!-- Test dependencies that need explicit versions -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/queue-java-aws-sdk-v2/pom.xml
+++ b/queue-java-aws-sdk-v2/pom.xml
@@ -50,4 +50,26 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>1.2.0-M1</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>5.2.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/queue-java-aws-sdk-v2/pom.xml
+++ b/queue-java-aws-sdk-v2/pom.xml
@@ -50,26 +50,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.2.0-M1</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>5.2.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/exception/QueueException.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/exception/QueueException.java
@@ -1,0 +1,12 @@
+package uk.gov.service.payments.commons.queue.exception;
+
+public class QueueException extends Exception {
+
+    public QueueException(){
+        
+    }
+    
+    public QueueException(String message) {
+        super(message);
+    }
+}

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/model/QueueMessage.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/model/QueueMessage.java
@@ -1,0 +1,48 @@
+package uk.gov.service.payments.commons.queue.model;
+
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class QueueMessage {
+
+    private String messageId;
+    private String receiptHandle;
+    private String messageBody;
+
+    private QueueMessage(String messageId, String receiptHandle, String messageBody) {
+        this.messageId = messageId;
+        this.receiptHandle = receiptHandle;
+        this.messageBody = messageBody;
+    }
+
+    private QueueMessage(String messageId, String messageBody) {
+        this(messageId, null, messageBody);
+    }
+
+    public static List<QueueMessage> of(ReceiveMessageResponse receiveMessageResult) {
+
+        return receiveMessageResult.messages()
+                .stream()
+                .map(c -> new QueueMessage(c.messageId(), c.receiptHandle(), c.body()))
+                .collect(Collectors.toList());
+    }
+
+    public static QueueMessage of(SendMessageResponse sendMessageResult, String messageBody) {
+        return new QueueMessage(sendMessageResult.messageId(), messageBody);
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public String getReceiptHandle() {
+        return receiptHandle;
+    }
+
+    public String getMessageBody() {
+        return messageBody;
+    }
+}

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/AbstractQueue.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/AbstractQueue.java
@@ -1,0 +1,46 @@
+package uk.gov.service.payments.commons.queue.sqs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
+import uk.gov.service.payments.commons.queue.model.QueueMessage;
+
+import java.util.List;
+
+public abstract class AbstractQueue {
+
+    private static final String MESSAGE_ATTRIBUTES_TO_RECEIVE = "All";
+    protected ObjectMapper objectMapper;
+    private String queueUrl;
+    private int failedMessageRetryDelayInSeconds;
+    private SqsQueueService sqsQueueService;
+
+    public AbstractQueue(SqsQueueService sqsQueueService, ObjectMapper objectMapper,
+                         String queueUrl, int failedMessageRetryDelayInSeconds) {
+        this.sqsQueueService = sqsQueueService;
+        this.queueUrl = queueUrl;
+        this.failedMessageRetryDelayInSeconds = failedMessageRetryDelayInSeconds;
+        this.objectMapper = objectMapper;
+    }
+
+    public QueueMessage sendMessageToQueue(String message) throws QueueException {
+        return sqsQueueService.sendMessage(queueUrl, message);
+    }
+
+    public QueueMessage sendMessageToQueueWithDelay(String message, int delayInSeconds) throws QueueException {
+        return sqsQueueService.sendMessage(queueUrl, message, delayInSeconds);
+    }
+
+    public List<QueueMessage> retrieveMessages() throws QueueException {
+        return sqsQueueService
+                .receiveMessages(this.queueUrl, MESSAGE_ATTRIBUTES_TO_RECEIVE);
+    }
+
+    public void markMessageAsProcessed(QueueMessage queueMessage) throws QueueException {
+        sqsQueueService.deleteMessage(this.queueUrl, queueMessage.getReceiptHandle());
+    }
+
+    public void scheduleMessageForRetry(QueueMessage queueMessage) throws QueueException {
+        sqsQueueService.deferMessage(this.queueUrl, queueMessage.getReceiptHandle(), failedMessageRetryDelayInSeconds);
+    }
+}
+

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -34,11 +34,19 @@ public class SqsQueueService {
     }
 
     public QueueMessage sendMessage(String queueUrl, String messageBody) throws QueueException {
-        return SendMessageRequest.builder()
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
                 .queueUrl(queueUrl)
                 .messageBody(messageBody)
                 .build();
+
+        try {
+            SendMessageResponse sendMessageResponse = sqsClient.sendMessage(sendMessageRequest);
+            return QueueMessage.of(sendMessageResponse, messageBody);
+        } catch (SqsException e) {
+            throw new QueueException("Failed to send message to SQS", e);
+        }
     }
+
 
     public QueueMessage sendMessage(String queueUrl, String messageBody, int delayInSeconds) throws QueueException {
         SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody).delaySeconds(delayInSeconds);

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -40,8 +40,7 @@ public class SqsQueueService {
                 .build();
 
         try {
-            SendMessageResponse sendMessageResponse = sqsClient.sendMessage(sendMessageRequest);
-            return QueueMessage.of(sendMessageResponse, messageBody);
+            return sendMessage(sendMessageRequest);
         } catch (SqsException e) {
             throw new QueueException(e.getMessage());
         }

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -75,7 +75,8 @@ public class SqsQueueService {
                     .queueUrl(queueUrl)
                     .messageAttributeNames(messageAttributeName)
                     .waitTimeSeconds(messageMaximumWaitTimeInSeconds)
-                    .maxNumberOfMessages(messageMaximumBatchSize);
+                    .maxNumberOfMessages(messageMaximumBatchSize)
+                    .build();
 
             ReceiveMessageResponse receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
 

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -35,7 +35,11 @@ public class SqsQueueService {
 
     public QueueMessage sendMessage(String queueUrl, String messageBody) throws QueueException {
         SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody);
-        return sendMessage(sendMessageRequest);
+        return SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(messageBody)
+                .build();
+
     }
 
     public QueueMessage sendMessage(String queueUrl, String messageBody, int delayInSeconds) throws QueueException {

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -1,0 +1,101 @@
+package uk.gov.service.payments.commons.queue.sqs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
+import uk.gov.service.payments.commons.queue.model.QueueMessage;
+
+import java.util.List;
+
+public class SqsQueueService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private SqsClient sqsClient;
+
+    private final int messageMaximumWaitTimeInSeconds;
+    private final int messageMaximumBatchSize;
+    
+    public SqsQueueService(SqsClient sqsClient, int messageMaximumWaitTimeInSeconds, int messageMaximumBatchSize) {
+        this.sqsClient = sqsClient;
+        this.messageMaximumWaitTimeInSeconds = messageMaximumWaitTimeInSeconds;
+        this.messageMaximumBatchSize = messageMaximumBatchSize;
+    }
+
+    public QueueMessage sendMessage(String queueUrl, String messageBody) throws QueueException {
+        SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody);
+        return sendMessage(sendMessageRequest);
+    }
+
+    public QueueMessage sendMessage(String queueUrl, String messageBody, int delayInSeconds) throws QueueException {
+        SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody).delaySeconds(delayInSeconds);
+        return sendMessage(sendMessageRequest);
+    }
+    
+    private QueueMessage sendMessage(SendMessageRequest sendMessageRequest) throws QueueException {
+        try {
+            SendMessageResponse sendMessageResult = sqsClient.sendMessage(sendMessageRequest);
+
+            logger.info("Message sent to SQS queue - {}", sendMessageResult);
+            return QueueMessage.of(sendMessageResult, sendMessageRequest.messageBody());
+        } catch (SqsException | UnsupportedOperationException e) {
+            logger.error("Failed sending message to SQS queue - {}", e.getMessage());
+            throw new QueueException(e.getMessage());
+        }
+    }
+    
+    public List<QueueMessage> receiveMessages(String queueUrl, String messageAttributeName) throws QueueException {
+        try {
+            ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
+            receiveMessageRequest
+                    .messageAttributeNames(messageAttributeName)
+                    .waitTimeSeconds(messageMaximumWaitTimeInSeconds)
+                    .maxNumberOfMessages(messageMaximumBatchSize);
+
+            ReceiveMessageResponse receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
+
+            return QueueMessage.of(receiveMessageResult);
+        } catch (SqsException | UnsupportedOperationException e) {
+            logger.error("Failed to receive messages from SQS queue - {}", e.getMessage());
+            throw new QueueException(e.getMessage());
+        }
+    }
+
+    public DeleteMessageResponse deleteMessage(String queueUrl, String messageReceiptHandle) throws QueueException {
+        try {
+            return sqsClient.deleteMessage(new DeleteMessageRequest(queueUrl, messageReceiptHandle));
+        } catch (SqsException | UnsupportedOperationException e) {
+            logger.error("Failed to delete message from SQS queue - {}", e.getMessage());
+            throw new QueueException(e.getMessage());
+        } catch (AwsServiceException e) {
+            logger.error("Failed to delete message from SQS queue - [errorMessage={}] [awsErrorCode={}]", e.getMessage(), e.awsErrorDetails().errorCode());
+            String errorMessage = String.format("%s [%s]", e.getMessage(), e.awsErrorDetails().errorCode());
+            throw new QueueException(errorMessage);
+        }
+    }
+
+    public ChangeMessageVisibilityResponse deferMessage(String queueUrl, String messageReceiptHandle, int timeoutInSeconds) throws QueueException {
+        try {
+            ChangeMessageVisibilityRequest changeMessageVisibilityRequest = new ChangeMessageVisibilityRequest(
+                    queueUrl,
+                    messageReceiptHandle,
+                    timeoutInSeconds);
+
+            return sqsClient.changeMessageVisibility(changeMessageVisibilityRequest);
+        } catch (SqsException | UnsupportedOperationException e) {
+            logger.error("Failed to defer message from SQS queue - {}", e.getMessage());
+            throw new QueueException(e.getMessage());
+        }
+    }
+}

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -43,7 +43,7 @@ public class SqsQueueService {
             SendMessageResponse sendMessageResponse = sqsClient.sendMessage(sendMessageRequest);
             return QueueMessage.of(sendMessageResponse, messageBody);
         } catch (SqsException e) {
-            throw new QueueException("Failed to send message to SQS", e);
+            throw new QueueException(e.getMessage());
         }
     }
 

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -49,7 +49,11 @@ public class SqsQueueService {
 
 
     public QueueMessage sendMessage(String queueUrl, String messageBody, int delayInSeconds) throws QueueException {
-        SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody).delaySeconds(delayInSeconds);
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(messageBody)
+                .delaySeconds(delayInSeconds)
+                .build();
         return sendMessage(sendMessageRequest);
     }
     
@@ -67,8 +71,8 @@ public class SqsQueueService {
     
     public List<QueueMessage> receiveMessages(String queueUrl, String messageAttributeName) throws QueueException {
         try {
-            ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
-            receiveMessageRequest
+            ReceiveMessageRequest receiveMessageRequest = ReceiveMessageRequest.builder()
+                    .queueUrl(queueUrl)
                     .messageAttributeNames(messageAttributeName)
                     .waitTimeSeconds(messageMaximumWaitTimeInSeconds)
                     .maxNumberOfMessages(messageMaximumBatchSize);
@@ -84,7 +88,11 @@ public class SqsQueueService {
 
     public DeleteMessageResponse deleteMessage(String queueUrl, String messageReceiptHandle) throws QueueException {
         try {
-            return sqsClient.deleteMessage(new DeleteMessageRequest(queueUrl, messageReceiptHandle));
+            DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .receiptHandle(messageReceiptHandle)
+                    .build();
+            return sqsClient.deleteMessage(deleteMessageRequest);
         } catch (SqsException | UnsupportedOperationException e) {
             logger.error("Failed to delete message from SQS queue - {}", e.getMessage());
             throw new QueueException(e.getMessage());
@@ -97,10 +105,11 @@ public class SqsQueueService {
 
     public ChangeMessageVisibilityResponse deferMessage(String queueUrl, String messageReceiptHandle, int timeoutInSeconds) throws QueueException {
         try {
-            ChangeMessageVisibilityRequest changeMessageVisibilityRequest = new ChangeMessageVisibilityRequest(
-                    queueUrl,
-                    messageReceiptHandle,
-                    timeoutInSeconds);
+            ChangeMessageVisibilityRequest changeVisibilityRequest = ChangeMessageVisibilityRequest.builder()
+                    .queueUrl(queueUrl)
+                    .receiptHandle(messageReceiptHandle)
+                    .visibilityTimeout(timeoutInSeconds)
+                    .build();
 
             return sqsClient.changeMessageVisibility(changeMessageVisibilityRequest);
         } catch (SqsException | UnsupportedOperationException e) {

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -112,7 +112,7 @@ public class SqsQueueService {
                     .visibilityTimeout(timeoutInSeconds)
                     .build();
 
-            return sqsClient.changeMessageVisibility(changeMessageVisibilityRequest);
+            return sqsClient.changeMessageVisibility(changeVisibilityRequest);
         } catch (SqsException | UnsupportedOperationException e) {
             logger.error("Failed to defer message from SQS queue - {}", e.getMessage());
             throw new QueueException(e.getMessage());

--- a/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-java-aws-sdk-v2/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -34,12 +34,10 @@ public class SqsQueueService {
     }
 
     public QueueMessage sendMessage(String queueUrl, String messageBody) throws QueueException {
-        SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody);
         return SendMessageRequest.builder()
                 .queueUrl(queueUrl)
                 .messageBody(messageBody)
                 .build();
-
     }
 
     public QueueMessage sendMessage(String queueUrl, String messageBody, int delayInSeconds) throws QueueException {

--- a/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
+++ b/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
@@ -118,14 +118,15 @@ public class SqsQueueServiceTest {
 
     @Test
     public void shouldReceiveMessagesFromQueueSuccessfully() throws QueueException {
-        ReceiveMessageResponse receiveMessageResult = ReceiveMessageResponse.builder()
-                .build();
         Message message = Message.builder()
+                .messageId("test-message-id")
+                .receiptHandle("test-receipt-handle")
+                .body("test-message-body")
                 .build();
-        message.messageId("test-message-id");
-        message.receiptHandle("test-receipt-handle");
-        message.body("test-message-body");
-        receiveMessageResult.messages().add(message);
+
+        ReceiveMessageResponse receiveMessageResult = ReceiveMessageResponse.builder()
+                .messages(message)
+                .build();
 
         when(mockSqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResult);
 

--- a/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
+++ b/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
@@ -1,0 +1,142 @@
+package uk.gov.service.payments.commons.queue.sqs;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
+import uk.gov.service.payments.commons.queue.exception.QueueException;
+import uk.gov.service.payments.commons.queue.model.QueueMessage;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SqsQueueServiceTest {
+
+    private static final String QUEUE_URL = "http://queue-url";
+    private static final String MESSAGE = "{chargeId: 123}";
+    private static final String MESSAGE_ATTRIBUTE_NAME = "All";
+
+    @Mock
+    private SqsClient mockSqsClient;
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+
+    private SqsQueueService sqsQueueService;
+
+    @Before
+    public void setUp() {
+        sqsQueueService = new SqsQueueService(mockSqsClient, 20, 10);
+
+        Logger root = (Logger) LoggerFactory.getLogger(SqsQueueService.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void shouldSendMessageToQueueSuccessfully() throws QueueException {
+        SendMessageResponse sendMessageResult = SendMessageResponse.builder()
+                .build();
+        sendMessageResult.messageId("test-message-id");
+        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE);
+        
+        when(mockSqsClient.sendMessage(sendMessageRequest)).thenReturn(sendMessageResult);
+
+        QueueMessage message = sqsQueueService.sendMessage(QUEUE_URL, MESSAGE);
+        assertEquals("test-message-id", message.getMessageId());
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Message sent to SQS queue - {MessageId: test-message-id")), is(true));
+    }
+
+    @Test
+    public void shouldSendMessageWithDelayToQueueSuccessfully() throws QueueException {
+        SendMessageResponse sendMessageResult = SendMessageResponse.builder()
+                .build();
+        sendMessageResult.messageId("test-message-id");
+        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE).delaySeconds(2);
+
+        when(mockSqsClient.sendMessage(sendMessageRequest)).thenReturn(sendMessageResult);
+
+        QueueMessage message = sqsQueueService.sendMessage(QUEUE_URL, MESSAGE, 2);
+        assertEquals("test-message-id", message.getMessageId());
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Message sent to SQS queue - {MessageId: test-message-id")), is(true));
+    }
+
+    @Test(expected = QueueException.class)
+    public void shouldThrowExceptionIfMessageIsNotSentToQueue() throws QueueException {
+        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE);
+        when(mockSqsClient.sendMessage(sendMessageRequest)).thenThrow(SqsException.class);
+
+        sqsQueueService.sendMessage(QUEUE_URL, MESSAGE);
+    }
+
+    @Test
+    public void shouldReceiveMessagesFromQueueSuccessfully() throws QueueException {
+        ReceiveMessageResponse receiveMessageResult = ReceiveMessageResponse.builder()
+                .build();
+        Message message = Message.builder()
+                .build();
+        message.messageId("test-message-id");
+        message.receiptHandle("test-receipt-handle");
+        message.body("test-message-body");
+        receiveMessageResult.messages().add(message);
+
+        when(mockSqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResult);
+
+        List<QueueMessage> queueMessages = sqsQueueService.receiveMessages(QUEUE_URL, MESSAGE_ATTRIBUTE_NAME);
+        Assert.assertThat(queueMessages.size(), is(1));
+        Assert.assertThat(queueMessages.get(0).getMessageId(), is("test-message-id"));
+        Assert.assertThat(queueMessages.get(0).getReceiptHandle(), is("test-receipt-handle"));
+        Assert.assertThat(queueMessages.get(0).getMessageBody(), is("test-message-body"));
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenReceiveDoesNotReturnAnyMessages() throws QueueException {
+        ReceiveMessageResponse receiveMessageResult = ReceiveMessageResponse.builder()
+                .build();
+        when(mockSqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenReturn(receiveMessageResult);
+
+        List<QueueMessage> queueMessages = sqsQueueService.receiveMessages(QUEUE_URL, MESSAGE_ATTRIBUTE_NAME);
+        assertTrue(queueMessages.isEmpty());
+    }
+
+    @Test(expected = QueueException.class)
+    public void shouldThrowExceptionIfMessageCannotBeReceivedFromQueue() throws QueueException {
+        when(mockSqsClient.receiveMessage(any(ReceiveMessageRequest.class))).thenThrow(SqsException.class);
+
+        sqsQueueService.receiveMessages(QUEUE_URL, MESSAGE_ATTRIBUTE_NAME);
+    }
+}

--- a/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
+++ b/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
@@ -78,7 +78,7 @@ public class SqsQueueServiceTest {
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Message sent to SQS queue - {MessageId: test-message-id")), is(true));
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Message sent to SQS queue - SendMessageResponse(MessageId=test-message-id)")), is(true));
     }
 
     @Test
@@ -101,7 +101,7 @@ public class SqsQueueServiceTest {
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
 
-        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Message sent to SQS queue - {MessageId: test-message-id")), is(true));
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Message sent to SQS queue - SendMessageResponse(MessageId=test-message-id)")), is(true));
     }
 
     @Test(expected = QueueException.class)

--- a/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
+++ b/queue-java-aws-sdk-v2/src/test/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueServiceTest.java
@@ -62,10 +62,14 @@ public class SqsQueueServiceTest {
     @Test
     public void shouldSendMessageToQueueSuccessfully() throws QueueException {
         SendMessageResponse sendMessageResult = SendMessageResponse.builder()
+                .messageId("test-message-id")
                 .build();
-        sendMessageResult.messageId("test-message-id");
-        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE);
-        
+
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(QUEUE_URL)
+                .messageBody(MESSAGE)
+                .build();
+
         when(mockSqsClient.sendMessage(sendMessageRequest)).thenReturn(sendMessageResult);
 
         QueueMessage message = sqsQueueService.sendMessage(QUEUE_URL, MESSAGE);
@@ -80,9 +84,14 @@ public class SqsQueueServiceTest {
     @Test
     public void shouldSendMessageWithDelayToQueueSuccessfully() throws QueueException {
         SendMessageResponse sendMessageResult = SendMessageResponse.builder()
+                .messageId("test-message-id")
                 .build();
-        sendMessageResult.messageId("test-message-id");
-        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE).delaySeconds(2);
+
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(QUEUE_URL)
+                .messageBody(MESSAGE)
+                .delaySeconds(2)
+                .build();
 
         when(mockSqsClient.sendMessage(sendMessageRequest)).thenReturn(sendMessageResult);
 
@@ -97,7 +106,11 @@ public class SqsQueueServiceTest {
 
     @Test(expected = QueueException.class)
     public void shouldThrowExceptionIfMessageIsNotSentToQueue() throws QueueException {
-        SendMessageRequest sendMessageRequest = new SendMessageRequest(QUEUE_URL, MESSAGE);
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(QUEUE_URL)
+                .messageBody(MESSAGE)
+                .build();
+        
         when(mockSqsClient.sendMessage(sendMessageRequest)).thenThrow(SqsException.class);
 
         sqsQueueService.sendMessage(QUEUE_URL, MESSAGE);


### PR DESCRIPTION
The AWS SDK for Java 1.x is in maintenance mode, effective July 31, 2024.

The AWS SDK for Java 1.x will no longer receive updates for new or existing services

The 1.x SDK will continue to receive critical bug fixes and security updates until December 31, 2025.

AWS recommend that we move to the java 2.x versions of the aws sdk