### PR TITLE
PP-14150 replace queue-dropwizard-4 with contents of queue-dropwizard-4-aws-sdk-v2 directory

### DIFF
--- a/queue-dropwizard-4/pom.xml
+++ b/queue-dropwizard-4/pom.xml
@@ -27,9 +27,9 @@
 
         <!-- Main dependencies that need explicit versions -->
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.12.782</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
+            <version>2.31.77</version>
         </dependency>
 
         <!-- Test dependencies that are imported from one of the BOMs specified

--- a/queue-dropwizard-4/src/main/java/uk/gov/service/payments/commons/queue/model/QueueMessage.java
+++ b/queue-dropwizard-4/src/main/java/uk/gov/service/payments/commons/queue/model/QueueMessage.java
@@ -1,7 +1,7 @@
 package uk.gov.service.payments.commons.queue.model;
 
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
-import com.amazonaws.services.sqs.model.SendMessageResult;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,16 +22,16 @@ public class QueueMessage {
         this(messageId, null, messageBody);
     }
 
-    public static List<QueueMessage> of(ReceiveMessageResult receiveMessageResult) {
+    public static List<QueueMessage> of(ReceiveMessageResponse receiveMessageResult) {
 
-        return receiveMessageResult.getMessages()
+        return receiveMessageResult.messages()
                 .stream()
-                .map(c -> new QueueMessage(c.getMessageId(), c.getReceiptHandle(), c.getBody()))
+                .map(c -> new QueueMessage(c.messageId(), c.receiptHandle(), c.body()))
                 .collect(Collectors.toList());
     }
 
-    public static QueueMessage of(SendMessageResult sendMessageResult, String messageBody) {
-        return new QueueMessage(sendMessageResult.getMessageId(), messageBody);
+    public static QueueMessage of(SendMessageResponse sendMessageResult, String messageBody) {
+        return new QueueMessage(sendMessageResult.messageId(), messageBody);
     }
 
     public String getMessageId() {

--- a/queue-dropwizard-4/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
+++ b/queue-dropwizard-4/src/main/java/uk/gov/service/payments/commons/queue/sqs/SqsQueueService.java
@@ -1,18 +1,18 @@
 package uk.gov.service.payments.commons.queue.sqs;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.AmazonSQSException;
-import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
-import com.amazonaws.services.sqs.model.ChangeMessageVisibilityResult;
-import com.amazonaws.services.sqs.model.DeleteMessageRequest;
-import com.amazonaws.services.sqs.model.DeleteMessageResult;
-import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
-import com.amazonaws.services.sqs.model.SendMessageResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityRequest;
+import software.amazon.awssdk.services.sqs.model.ChangeMessageVisibilityResponse;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+import software.amazon.awssdk.services.sqs.model.SqsException;
 import uk.gov.service.payments.commons.queue.exception.QueueException;
 import uk.gov.service.payments.commons.queue.model.QueueMessage;
 
@@ -22,78 +22,97 @@ public class SqsQueueService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private AmazonSQS sqsClient;
+    private SqsClient sqsClient;
 
     private final int messageMaximumWaitTimeInSeconds;
     private final int messageMaximumBatchSize;
     
-    public SqsQueueService(AmazonSQS sqsClient, int messageMaximumWaitTimeInSeconds, int messageMaximumBatchSize) {
+    public SqsQueueService(SqsClient sqsClient, int messageMaximumWaitTimeInSeconds, int messageMaximumBatchSize) {
         this.sqsClient = sqsClient;
         this.messageMaximumWaitTimeInSeconds = messageMaximumWaitTimeInSeconds;
         this.messageMaximumBatchSize = messageMaximumBatchSize;
     }
 
+
     public QueueMessage sendMessage(String queueUrl, String messageBody) throws QueueException {
-        SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody);
-        return sendMessage(sendMessageRequest);
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(messageBody)
+                .build();
+
+        try {
+            return sendMessage(sendMessageRequest);
+        } catch (SqsException e) {
+            throw new QueueException(e.getMessage());
+        }
     }
 
     public QueueMessage sendMessage(String queueUrl, String messageBody, int delayInSeconds) throws QueueException {
-        SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, messageBody).withDelaySeconds(delayInSeconds);
+        SendMessageRequest sendMessageRequest = SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(messageBody)
+                .delaySeconds(delayInSeconds)
+                .build();
         return sendMessage(sendMessageRequest);
     }
     
     private QueueMessage sendMessage(SendMessageRequest sendMessageRequest) throws QueueException {
         try {
-            SendMessageResult sendMessageResult = sqsClient.sendMessage(sendMessageRequest);
+            SendMessageResponse sendMessageResult = sqsClient.sendMessage(sendMessageRequest);
 
             logger.info("Message sent to SQS queue - {}", sendMessageResult);
-            return QueueMessage.of(sendMessageResult, sendMessageRequest.getMessageBody());
-        } catch (AmazonSQSException | UnsupportedOperationException e) {
+            return QueueMessage.of(sendMessageResult, sendMessageRequest.messageBody());
+        } catch (SqsException | UnsupportedOperationException e) {
             logger.error("Failed sending message to SQS queue - {}", e.getMessage());
             throw new QueueException(e.getMessage());
         }
     }
-    
+
     public List<QueueMessage> receiveMessages(String queueUrl, String messageAttributeName) throws QueueException {
         try {
-            ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
-            receiveMessageRequest
-                    .withMessageAttributeNames(messageAttributeName)
-                    .withWaitTimeSeconds(messageMaximumWaitTimeInSeconds)
-                    .withMaxNumberOfMessages(messageMaximumBatchSize);
+            ReceiveMessageRequest receiveMessageRequest = ReceiveMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .messageAttributeNames(messageAttributeName)
+                    .waitTimeSeconds(messageMaximumWaitTimeInSeconds)
+                    .maxNumberOfMessages(messageMaximumBatchSize)
+                    .build();
 
-            ReceiveMessageResult receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
+            ReceiveMessageResponse receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
 
             return QueueMessage.of(receiveMessageResult);
-        } catch (AmazonSQSException | UnsupportedOperationException e) {
+        } catch (SqsException | UnsupportedOperationException e) {
             logger.error("Failed to receive messages from SQS queue - {}", e.getMessage());
             throw new QueueException(e.getMessage());
         }
     }
 
-    public DeleteMessageResult deleteMessage(String queueUrl, String messageReceiptHandle) throws QueueException {
+    public DeleteMessageResponse deleteMessage(String queueUrl, String messageReceiptHandle) throws QueueException {
         try {
-            return sqsClient.deleteMessage(new DeleteMessageRequest(queueUrl, messageReceiptHandle));
-        } catch (AmazonSQSException | UnsupportedOperationException e) {
+            DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+                    .queueUrl(queueUrl)
+                    .receiptHandle(messageReceiptHandle)
+                    .build();
+            return sqsClient.deleteMessage(deleteMessageRequest);
+        } catch (SqsException | UnsupportedOperationException e) {
             logger.error("Failed to delete message from SQS queue - {}", e.getMessage());
             throw new QueueException(e.getMessage());
-        } catch (AmazonServiceException e) {
-            logger.error("Failed to delete message from SQS queue - [errorMessage={}] [awsErrorCode={}]", e.getMessage(), e.getErrorCode());
-            String errorMessage = String.format("%s [%s]", e.getMessage(), e.getErrorCode());
+        } catch (AwsServiceException e) {
+            logger.error("Failed to delete message from SQS queue - [errorMessage={}] [awsErrorCode={}]", e.getMessage(), e.awsErrorDetails().errorCode());
+            String errorMessage = String.format("%s [%s]", e.getMessage(), e.awsErrorDetails().errorCode());
             throw new QueueException(errorMessage);
         }
     }
 
-    public ChangeMessageVisibilityResult deferMessage(String queueUrl, String messageReceiptHandle, int timeoutInSeconds) throws QueueException {
+    public ChangeMessageVisibilityResponse deferMessage(String queueUrl, String messageReceiptHandle, int timeoutInSeconds) throws QueueException {
         try {
-            ChangeMessageVisibilityRequest changeMessageVisibilityRequest = new ChangeMessageVisibilityRequest(
-                    queueUrl,
-                    messageReceiptHandle,
-                    timeoutInSeconds);
+            ChangeMessageVisibilityRequest changeVisibilityRequest = ChangeMessageVisibilityRequest.builder()
+                    .queueUrl(queueUrl)
+                    .receiptHandle(messageReceiptHandle)
+                    .visibilityTimeout(timeoutInSeconds)
+                    .build();
 
-            return sqsClient.changeMessageVisibility(changeMessageVisibilityRequest);
-        } catch (AmazonSQSException | UnsupportedOperationException e) {
+            return sqsClient.changeMessageVisibility(changeVisibilityRequest);
+        } catch (SqsException | UnsupportedOperationException e) {
             logger.error("Failed to defer message from SQS queue - {}", e.getMessage());
             throw new QueueException(e.getMessage());
         }


### PR DESCRIPTION
Relevant services have now been updated with the new AWS Java SDK V2. We still have the old `queue-dropwizard-4` directory in the java commons repository which while unused, still has V1 as a dependancy and is therefore still receiving dependabot updates. This PR replaces the `queue-dropwizard-4` directory with the contents of `queue-dropwizard-4-aws-sdk-v2`. After this is deployed we can then point the relevant services to use this queue directory and then safely delete what will be the superfluous `queue-dropwizard-4-aws-sdk-v2`.

**To Test**
Pull the branch and follow the [manual](https://manual.payments.service.gov.uk/manual/how-to/test-pay-java-commons-locally.html) to use your local version of `pay-java-commons`. Then run the tests in the local project not before changing the lines:
```
<dependency>
            <groupId>uk.gov.service.payments</groupId>
            <artifactId>queue-dropwizard-4-aws-sdk-v2</artifactId>
            <version>${pay-java-commons.version}</version>
        </dependency>
```

To:
```<dependency>
            <groupId>uk.gov.service.payments</groupId>
            <artifactId>queue-dropwizard-4</artifactId>
            <version>${pay-java-commons.version}</version>
        </dependency>
```