### PR TITLE
PP-14301 upgrade actions/setup-java

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install Java and Maven
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9  # v4.2.1
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,7 @@
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
+                    <deploymentName>pay-java-commons</deploymentName>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
### WHAT

- bump action to `4.7.1`
- give maven central deployment a sensible name