### PR TITLE
PP-14410 Add agreement payment type schema as model

### DIFF
--- a/model-dropwizard-4/src/main/java/uk/gov/service/payments/commons/model/AgreementPaymentType.java
+++ b/model-dropwizard-4/src/main/java/uk/gov/service/payments/commons/model/AgreementPaymentType.java
@@ -1,0 +1,31 @@
+package uk.gov.service.payments.commons.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.stream.Stream;
+
+public enum AgreementPaymentType {
+    @JsonProperty("instalment")
+    INSTALMENT("instalment"),
+    @JsonProperty("recurring")
+    RECURRING("recurring"),
+    @JsonProperty("unscheduled")
+    UNSCHEDULED("unscheduled");
+
+    private final String name;
+
+    AgreementPaymentType(String name) {
+        this.name = name;
+    }
+    
+    public static AgreementPaymentType of(String name) {
+        return Stream.of(AgreementPaymentType.values())
+                .filter(n -> n.getName().equals(name))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}


### PR DESCRIPTION
Adding the agreement payment type schema for use with recurring payments with valid reasons for the payments with values of either `instalment`, `unscheduled` or `recurring`. 